### PR TITLE
chore: update renovate config to automerge stable deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
 		"config:recommended",
 		":pinDevDependencies",
 		":pinDependencies",
-		":automergeMinor"
+		":automergeStableNonMajor"
 	],
 	"lockFileMaintenance": { "enabled": true, "automerge": true },
 	"packageRules": [


### PR DESCRIPTION
Change automerge strategy from minor versions to stable non-major
versions to reduce risk of breaking changes while keeping dependencies
up to date automatically. This improves stability and maintenance.