### PR TITLE
chore(renovate): group Playwright packages for updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
 	"lockFileMaintenance": { "enabled": true, "automerge": true },
 	"packageRules": [
 		{ "matchPackageNames": ["/relay/"], "groupName": "relay" },
+		{
+			"matchPackageNames": ["mcr.microsoft.com/playwright", "@playwright/*"],
+			"groupName": "playwright"
+		},
 		{ "matchPackageNames": ["/oxlint/"], "groupName": "oxlint" },
 		{ "matchDepTypes": ["devDependencies", "action"], "automerge": true },
 		{


### PR DESCRIPTION
Add a new package rule to group Playwright-related dependencies
(mcr.microsoft.com/playwright and @playwright/*) under a single
group named "playwright". This change improves dependency update
management by consolidating Playwright package updates for easier
tracking and automerging.