### PR TITLE
feat(web): enable experiment logs and set full trace sampling

### DIFF
--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -32,6 +32,7 @@ init({
 		replayIntegration(),
 	],
 
+	_experiments: { enableLogs: true },
 	tracesSampleRate: 1.0, //  Capture 100% of the transactions
 
 	// Set `tracePropagationTargets` to declare which URL(s) should have trace propagation enabled

--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -21,6 +21,7 @@ init({
 			? `production`
 			: "preview",
 	dsn: "https://b72170d9bac5ee68ab3ce649b3aad356@o4508677510201344.ingest.de.sentry.io/4508677512888400",
+	sendDefaultPii: true,
 	integrations: [
 		reactRouterV7BrowserTracingIntegration({
 			createRoutesFromChildren: createRoutesFromChildren,


### PR DESCRIPTION
Add _experiments flag to enable detailed logging for debugging
purposes. Set tracesSampleRate to 1.0 to capture 100% of
transactions for improved monitoring and performance analysis.