### PR TITLE
fix(dev): remove dts from dev watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"turbo:lint": "turbo run lint --continue=dependencies-successful --affected",
 		"lint": "eslint --cache . --fix",
 		"eslint-typegen": "node --import=tsx eslint.config.ts",
-		"dev": "turbo watch dev dts relay-watch",
+		"dev": "turbo watch dev relay-watch",
 		"format": "prettier . -w --cache --experimental-cli",
 		"test": "vitest --run --changed origin/master",
 		"test-e2e": "turbo run test-e2e --continue=dependencies-successful --log-order=stream",


### PR DESCRIPTION
- Removed the dts task from the turbo watch command in the dev script
- Improved development performance by skipping unnecessary type generation during watch
- Reduced overhead in the development process