### PR TITLE
refactor: inline GraphQL fragments and queries for clarity

### DIFF
--- a/apps/web/app/lib/entry/Behind.ts
+++ b/apps/web/app/lib/entry/Behind.ts
@@ -4,22 +4,23 @@ import type { Behind_entry$key } from "~/gql/Behind_entry.graphql"
 import { readFragment } from "../Network"
 const { graphql } = ReactRelay
 
-const Behind_entry = graphql`
-	fragment Behind_entry on MediaList {
-		id
-		progress
-		media {
-			id
-			avalible @required(action: NONE)
-		}
-	}
-`
-
 /**
  * @RelayResolver MediaList.behind: Int
  * @rootFragment Behind_entry*/
 export function behind(data: Behind_entry$key): number | null {
-	const entry = readFragment(Behind_entry, data)
+	const entry = readFragment(
+		graphql`
+			fragment Behind_entry on MediaList {
+				id
+				progress
+				media {
+					id
+					avalible @required(action: NONE)
+				}
+			}
+		`,
+		data
+	)
 
 	const avalible = entry.media?.avalible
 

--- a/apps/web/app/lib/entry/MediaCover.tsx
+++ b/apps/web/app/lib/entry/MediaCover.tsx
@@ -6,18 +6,6 @@ import { useFragment } from "../Network"
 
 const { graphql } = ReactRelay
 
-const MediaCover_media = graphql`
-	fragment MediaCover_media on Media
-	@argumentDefinitions(extraLarge: { type: "Boolean", defaultValue: false }) {
-		id
-		coverImage {
-			extraLarge @include(if: $extraLarge)
-			large
-			medium
-		}
-	}
-`
-
 import { tv } from "~/lib/tailwind-variants"
 
 const cover = tv({
@@ -31,7 +19,22 @@ interface MediaCoverProps extends Ariakit.RoleProps<"img"> {
 }
 
 export function MediaCover({ media, ...props }: MediaCoverProps): ReactNode {
-	const data = useFragment(MediaCover_media, media)
+	const data = useFragment(
+		graphql`
+			fragment MediaCover_media on Media
+			@argumentDefinitions(
+				extraLarge: { type: "Boolean", defaultValue: false }
+			) {
+				id
+				coverImage {
+					extraLarge @include(if: $extraLarge)
+					large
+					medium
+				}
+			}
+		`,
+		media
+	)
 
 	return (
 		<Ariakit.Role.img

--- a/apps/web/app/lib/entry/ToWatch.ts
+++ b/apps/web/app/lib/entry/ToWatch.ts
@@ -5,22 +5,23 @@ import { readFragment } from "../Network"
 
 const { graphql } = ReactRelay
 
-const ToWatch_entry = graphql`
-	fragment ToWatch_entry on MediaList {
-		behind @required(action: NONE)
-		media {
-			duration
-			id
-		}
-		id
-	}
-`
-
 /**
  * @RelayResolver MediaList.toWatch: Int
  * @rootFragment ToWatch_entry*/
 export function toWatch(data: ToWatch_entry$key): number | null {
-	const entry = readFragment(ToWatch_entry, data)
+	const entry = readFragment(
+		graphql`
+			fragment ToWatch_entry on MediaList {
+				behind @required(action: NONE)
+				media {
+					duration
+					id
+				}
+				id
+			}
+		`,
+		data
+	)
 
 	if (!entry) {
 		return null

--- a/apps/web/app/lib/list/MediaList.tsx
+++ b/apps/web/app/lib/list/MediaList.tsx
@@ -34,17 +34,19 @@ export function AwaitLibrary({
 	)
 }
 
-const MediaListHeaderToWatch_entries = graphql`
-	fragment MediaListHeaderToWatch_entries on MediaList @relay(plural: true) {
-		id
-		toWatch
-	}
-`
-
 export function MediaListHeaderToWatch(props: {
 	entries: MediaListHeaderToWatch_entries$key
 }): string {
-	const entries = useFragment(MediaListHeaderToWatch_entries, props.entries)
+	const entries = useFragment(
+		graphql`
+			fragment MediaListHeaderToWatch_entries on MediaList
+			@relay(plural: true) {
+				id
+				toWatch
+			}
+		`,
+		props.entries
+	)
 
 	return formatWatch(
 		entries

--- a/apps/web/app/lib/media/Avalible.ts
+++ b/apps/web/app/lib/media/Avalible.ts
@@ -6,24 +6,25 @@ import type {
 import { readFragment } from "../Network"
 const { graphql } = ReactRelay
 
-const Avalible_media = graphql`
-	fragment Avalible_media on Media {
-		status(version: 2)
-		episodes
-		chapters
-		nextAiringEpisode {
-			id
-			episode
-		}
-		id
-	}
-`
-
 /**
  * @RelayResolver Media.avalible: Int
  * @rootFragment Avalible_media*/
 export function avalible(key: Avalible_media$key): number | null | undefined {
-	const media = readFragment(Avalible_media, key)
+	const media = readFragment(
+		graphql`
+			fragment Avalible_media on Media {
+				status(version: 2)
+				episodes
+				chapters
+				nextAiringEpisode {
+					id
+					episode
+				}
+				id
+			}
+		`,
+		key
+	)
 
 	if (media.status == null) {
 		return null

--- a/apps/web/app/lib/media/Theme.ts
+++ b/apps/web/app/lib/media/Theme.ts
@@ -4,17 +4,18 @@ import { readFragment } from "../Network"
 import { getThemeFromHex, type Theme } from "../theme"
 const { graphql } = ReactRelay
 
-const Theme_mediaCover = graphql`
-	fragment Theme_mediaCover on MediaCoverImage {
-		color
-	}
-`
-
 /**
  * @RelayResolver MediaCoverImage.theme: RelayResolverValue
  * @rootFragment Theme_mediaCover*/
 export function theme(key: Theme_mediaCover$key): Theme | null {
-	const media = readFragment(Theme_mediaCover, key)
+	const media = readFragment(
+		graphql`
+			fragment Theme_mediaCover on MediaCoverImage {
+				color
+			}
+		`,
+		key
+	)
 
 	return media.color ? getThemeFromHex(media.color) : null
 }

--- a/apps/web/app/lib/search/SearchItem.tsx
+++ b/apps/web/app/lib/search/SearchItem.tsx
@@ -15,24 +15,25 @@ import { useFragment } from "../Network"
 import { route_media } from "../route"
 const { graphql } = ReactRelay
 
-const SearchItem_media = graphql`
-	fragment SearchItem_media on Media {
-		id
-		type
-		...MediaCover_media
-		title @required(action: LOG) {
-			userPreferred @required(action: LOG)
-		}
-	}
-`
-
 export function SearchItem({
 	media,
 	...props
 }: {
 	media: SearchItem_media$key
 }) {
-	const data = useFragment(SearchItem_media, media)
+	const data = useFragment(
+		graphql`
+			fragment SearchItem_media on Media {
+				id
+				type
+				...MediaCover_media
+				title @required(action: LOG) {
+					userPreferred @required(action: LOG)
+				}
+			}
+		`,
+		media
+	)
 
 	return (
 		data && (

--- a/apps/web/app/lib/search/SearchTrending.tsx
+++ b/apps/web/app/lib/search/SearchTrending.tsx
@@ -16,21 +16,22 @@ import ReactRelay from "react-relay"
 import type { SearchTrending_query$key } from "~/gql/SearchTrending_query.graphql"
 const { graphql } = ReactRelay
 
-const SearchTrending_query = graphql`
-	fragment SearchTrending_query on Query {
-		trending: Page(perPage: 10) {
-			media(sort: [TRENDING_DESC]) {
-				id
-				...SearchItem_media
-			}
-		}
-	}
-`
-
 export function SearchTrending(props: {
 	query: SearchTrending_query$key
 }): ReactNode {
-	const data = useFragment(SearchTrending_query, props.query)
+	const data = useFragment(
+		graphql`
+			fragment SearchTrending_query on Query {
+				trending: Page(perPage: 10) {
+					media(sort: [TRENDING_DESC]) {
+						id
+						...SearchItem_media
+					}
+				}
+			}
+		`,
+		props.query
+	)
 
 	return data.trending?.media && data.trending.media.length > 0 ? (
 		<SearchViewBody>

--- a/apps/web/app/routes/Notifications/route.tsx
+++ b/apps/web/app/routes/Notifications/route.tsx
@@ -35,7 +35,38 @@ export const clientLoader = (args: ClientLoaderFunctionArgs) => {
 	return {
 		routeNavNotificationsQuery: args.context.get(
 			loadQuery
-		)<routeNavNotificationsQueryOperation>(routeNavNotificationsQuery, {}),
+		)<routeNavNotificationsQueryOperation>(
+			graphql`
+				query routeNavNotificationsQuery {
+					Viewer @required(action: THROW) {
+						id
+						unreadNotificationCount
+						...Airing_viewer
+						...RelatedMediaAddition_viewer
+						...ActivityLike_viewer
+					}
+					Page {
+						notifications(
+							type_in: [AIRING, RELATED_MEDIA_ADDITION, ACTIVITY_LIKE]
+						) {
+							... on AiringNotification {
+								id
+								...Airing_notification @alias
+							}
+							... on RelatedMediaAdditionNotification {
+								id
+								...RelatedMediaAddition_notification @alias
+							}
+							... on ActivityLikeNotification {
+								id
+								...ActivityLike_notification @alias
+							}
+						}
+					}
+				}
+			`,
+			{}
+		),
 	}
 }
 
@@ -57,34 +88,6 @@ export const clientAction = (async () => {
 
 	return redirect(".")
 }) satisfies ActionFunction
-
-const routeNavNotificationsQuery = graphql`
-	query routeNavNotificationsQuery {
-		Viewer @required(action: THROW) {
-			id
-			unreadNotificationCount
-			...Airing_viewer
-			...RelatedMediaAddition_viewer
-			...ActivityLike_viewer
-		}
-		Page {
-			notifications(type_in: [AIRING, RELATED_MEDIA_ADDITION, ACTIVITY_LIKE]) {
-				... on AiringNotification {
-					id
-					...Airing_notification @alias
-				}
-				... on RelatedMediaAdditionNotification {
-					id
-					...RelatedMediaAddition_notification @alias
-				}
-				... on ActivityLikeNotification {
-					id
-					...ActivityLike_notification @alias
-				}
-			}
-		}
-	}
-`
 
 export default function Page({ loaderData }: Route.ComponentProps): ReactNode {
 	const data = usePreloadedQuery(loaderData.routeNavNotificationsQuery)

--- a/apps/web/app/routes/User/User.tsx
+++ b/apps/web/app/routes/User/User.tsx
@@ -10,24 +10,25 @@ import type { User_user$key } from "~/gql/User_user.graphql"
 
 const { graphql } = ReactRelay
 
-const User_user = graphql`
-	fragment User_user on User {
-		id
-		name
-		bannerImage
-		avatar {
-			large
-			medium
-		}
-	}
-`
-
 interface UserProps extends ComponentProps<"div"> {
 	user: User_user$key
 }
 
 export function User({ user, ...props }: UserProps): ReactNode {
-	const data = useFragment(User_user, user)
+	const data = useFragment(
+		graphql`
+			fragment User_user on User {
+				id
+				name
+				bannerImage
+				avatar {
+					large
+					medium
+				}
+			}
+		`,
+		user
+	)
 	const src = data.avatar?.large ?? data.avatar?.medium
 
 	return (

--- a/apps/web/app/routes/User/user-profile-theme-resolver.ts
+++ b/apps/web/app/routes/User/user-profile-theme-resolver.ts
@@ -4,19 +4,20 @@ import { readFragment } from "~/lib/Network"
 import { getThemeFromHex, type Theme } from "~/lib/theme"
 const { graphql } = ReactRelay
 
-const userProfileThemeResolver_userOptions = graphql`
-	fragment userProfileThemeResolver_userOptions on UserOptions {
-		profileColor
-	}
-`
-
 /**
  * @RelayResolver UserOptions.profileTheme: RelayResolverValue
  * @rootFragment userProfileThemeResolver_userOptions*/
 export function profileTheme(
 	key: userProfileThemeResolver_userOptions$key
 ): Theme | null {
-	const options = readFragment(userProfileThemeResolver_userOptions, key)
+	const options = readFragment(
+		graphql`
+			fragment userProfileThemeResolver_userOptions on UserOptions {
+				profileColor
+			}
+		`,
+		key
+	)
 
 	const color = options.profileColor
 		? {

--- a/apps/web/app/routes/UserFollow/route.tsx
+++ b/apps/web/app/routes/UserFollow/route.tsx
@@ -11,16 +11,6 @@ import { invariant } from "~/lib/invariant"
 import { m } from "~/lib/paraglide"
 const { graphql } = ReactRelay
 
-const UserFollow = graphql`
-	mutation routeUserFollowMutation($userId: Int!) {
-		ToggleFollow(userId: $userId) {
-			id
-			name @required(action: LOG)
-			isFollowing
-		}
-	}
-`
-
 const Params = type({ userId: "string.integer.parse" })
 export const clientAction = (async (args) => {
 	const params = invariant(Params(args.params))
@@ -28,7 +18,15 @@ export const clientAction = (async (args) => {
 	const client = client_get_client()
 
 	const data = await client.mutation<routeUserFollowMutation>({
-		mutation: UserFollow,
+		mutation: graphql`
+			mutation routeUserFollowMutation($userId: Int!) {
+				ToggleFollow(userId: $userId) {
+					id
+					name @required(action: LOG)
+					isFollowing
+				}
+			}
+		`,
 		variables: { userId: params.userId },
 	})
 


### PR DESCRIPTION
Replace standalone GraphQL fragment declarations with inline
fragments inside useFragment and readFragment calls across multiple
components and resolver functions. This improves code locality and
readability by keeping the fragment definitions close to their usage.

Also, move the UserFollow mutation definition inline within the client
mutation call to reduce indirection.

Update the Notifications route query to be defined inline, adding
explicit selection of notification types and their fragments to
ensure all required data is fetched.

These changes simplify the codebase and make GraphQL dependencies more
transparent and maintainable.