### PR TITLE
fix(dev): remove relay-watch from dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"turbo:lint": "turbo run lint --continue=dependencies-successful --affected",
 		"lint": "eslint --cache . --fix",
 		"eslint-typegen": "node --import=tsx eslint.config.ts",
-		"dev": "turbo watch dev relay-watch",
+		"dev": "turbo watch dev",
 		"format": "prettier . -w --cache --experimental-cli",
 		"test": "vitest --run --changed origin/master",
 		"test-e2e": "turbo run test-e2e --continue=dependencies-successful --log-order=stream",


### PR DESCRIPTION
Update the dev script in package.json to remove relay-watch from
the turbo watch command. This change simplifies the development
workflow by focusing only on the dev task, improving performance
and reducing unnecessary watch processes.