### PR TITLE
chore: add devEngines field to specify dev environment requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,15 @@
 	"packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
 	"engines": {
 		"node": ">=22.14.0"
+	},
+	"devEngines": {
+		"packageManager": {
+			"name": "pnpm",
+			"version": "10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+		},
+		"runtime": {
+			"name": "node",
+			"version": ">=22.14.0"
+		}
 	}
 }


### PR DESCRIPTION
Add a devEngines section in package.json to explicitly define the
package manager and Node.js runtime versions required for development.
This helps ensure consistent environments for contributors and CI systems.