### PR TITLE
chore: remove deprecated ui setting from turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://turbo.build/schema.json",
-	"ui": "tui",
 	"envMode": "strict",
 	"globalPassThroughEnv": [
 		"DEV",


### PR DESCRIPTION
Remove the "ui": "tui" configuration from turbo.json to align with
the latest schema and avoid potential conflicts. This change ensures
compatibility with the current version of Turbo and enforces strict
environment mode settings.