### PR TITLE
fix: update babel plugin config in vite to include app tsx files

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,7 +13,11 @@ export default defineConfig({
 	plugins: [
 		inspect(),
 		tailwindcss(),
-		babel({ filter: /\.[jt]sx?$/, exclude: [/~icons/], apply: () => false }),
+		babel({
+			filter: /\.[jt]sx?$/,
+			include: ["./app/**/*.tsx"],
+			exclude: [/~icons/],
+		}),
 		paraglide({ project: "./project.inlang", outdir: "./app/paraglide" }),
 
 		reactRouter(),


### PR DESCRIPTION
Modify babel plugin settings to explicitly include all TSX files
under the ./app directory while excluding the /~icons/ folder. This
ensures proper transpilation of application components and improves
build accuracy.