### PR TITLE
fix(web): remove target option from react compiler plugin

### DIFF
--- a/apps/web/babel.config.cjs
+++ b/apps/web/babel.config.cjs
@@ -6,5 +6,5 @@ module.exports = {
 		],
 	],
 	babelrc: false,
-	plugins: [["babel-plugin-react-compiler", { target: "19" }]],
+	plugins: ["babel-plugin-react-compiler"],
 }


### PR DESCRIPTION
Remove the target option from the babel-plugin-react-compiler
configuration in the web app. This change simplifies the plugin
setup and ensures compatibility with the latest React compiler
defaults.