### PR TITLE
fix(tailwind): correct opacity calculation for numeric values

### DIFF
--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -88,7 +88,7 @@ export const config = {
 								- Number(
 									Predicate.isString(opacity)
 										? opacity.replace("%", "")
-										: Number(opacity) * 100
+										: opacity * 100
 								)
 						)}%)`
 


### PR DESCRIPTION
Fix opacity calculation in tailwind.config.ts to multiply numeric
opacity values by 100 directly instead of converting them to Number
first. This ensures correct handling of opacity when it is already a
number, preventing potential errors in style generation.