### PR TITLE
feat(web): add useEffectEvent hook and improve keydown handler

### DIFF
--- a/apps/web/app/lib/search/Search.tsx
+++ b/apps/web/app/lib/search/Search.tsx
@@ -48,6 +48,7 @@ function useOptimisticLocation() {
 }
 
 import type { routeNavQuery } from "~/gql/routeNavQuery.graphql"
+import { useEffectEvent } from "../use-effect-event"
 
 export function Search({
 	queryRef,
@@ -65,19 +66,20 @@ export function Search({
 	sheetParams.set("sheet", "search")
 	const navigate = useNavigate()
 
+	const listener = useEffectEvent((event: KeyboardEvent) => {
+		if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+			event.preventDefault()
+			void navigate({ search: `?${sheetParams}` })
+		}
+	})
+
 	// bind command + k
 	useEffect(() => {
-		const listener = (event: KeyboardEvent) => {
-			if ((event.metaKey || event.ctrlKey) && event.key === "k") {
-				event.preventDefault()
-				void navigate({ search: `?${sheetParams}` })
-			}
-		}
 		window.addEventListener("keydown", listener)
 		return () => {
 			window.removeEventListener("keydown", listener)
 		}
-	}, [navigate, sheetParams])
+	}, [listener])
 
 	const media = submit.data?.page?.media?.filter((el) => el != null) ?? []
 

--- a/apps/web/app/lib/use-effect-event.ts
+++ b/apps/web/app/lib/use-effect-event.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useRef } from "react"
+
+export function useEffectEvent<Fn extends (...args: any[]) => any>(
+	callback: Fn
+) {
+	const ref = useRef<Fn>(callback)
+
+	useEffect(() => {
+		ref.current = callback
+	})
+
+	return useCallback(
+		(...args: Parameters<Fn>): ReturnType<Fn> => {
+			return ref.current(...args)
+		},
+		[ref]
+	)
+}

--- a/apps/web/app/lib/use-effect-event.ts
+++ b/apps/web/app/lib/use-effect-event.ts
@@ -1,18 +1,16 @@
 import { useCallback, useEffect, useRef } from "react"
 
-export function useEffectEvent<Fn extends (...args: any[]) => any>(
-	callback: Fn
-) {
-	const ref = useRef<Fn>(callback)
+export function useEffectEvent<T extends Function>(event: T) {
+	const ref = useRef<T>(event)
 
 	useEffect(() => {
-		ref.current = callback
+		ref.current = event
 	})
 
 	return useCallback(
-		(...args: Parameters<Fn>): ReturnType<Fn> => {
+		((...args: unknown[]) => {
 			return ref.current(...args)
-		},
+		}) as unknown as T,
 		[ref]
 	)
 }

--- a/apps/web/app/lib/use-effect-event.ts
+++ b/apps/web/app/lib/use-effect-event.ts
@@ -1,16 +1,18 @@
 import { useCallback, useEffect, useRef } from "react"
 
-export function useEffectEvent<T extends Function>(event: T) {
-	const ref = useRef<T>(event)
+export function useEffectEvent<Args extends unknown[], T extends unknown>(
+	event: (...args: Args) => T
+) {
+	const ref = useRef(event)
 
 	useEffect(() => {
 		ref.current = event
 	})
 
 	return useCallback(
-		((...args: unknown[]) => {
+		(...args: Args): T => {
 			return ref.current(...args)
-		}) as unknown as T,
+		},
 		[ref]
 	)
 }


### PR DESCRIPTION
Introduce useEffectEvent hook to create stable event callbacks that
always reference the latest callback without reattaching listeners.

Refactor Search component to use useEffectEvent for the keydown
listener, preventing unnecessary effect re-runs and improving
 when handling the command/ctrl + k shortcut.