### PR TITLE
fix: simplify generic type in useEffectEvent hook

### DIFF
--- a/apps/web/app/lib/use-effect-event.ts
+++ b/apps/web/app/lib/use-effect-event.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react"
 
-export function useEffectEvent<Args extends unknown[], T extends unknown>(
+export function useEffectEvent<Args extends unknown[], T>(
 	event: (...args: Args) => T
 ) {
 	const ref = useRef(event)


### PR DESCRIPTION
Refactor useEffectEvent to remove unnecessary generic constraint
on type parameter T. This change improves code readability and
maintainability without affecting functionality.