### PR TITLE
fix: restrict letterSpacing token parameter to needed props

### DIFF
--- a/apps/web/tailwind.config.fonts.ts
+++ b/apps/web/tailwind.config.fonts.ts
@@ -39,6 +39,6 @@ export function pxToRem(px: number) {
 	return `${numberToString(px / 16)}rem`
 }
 
-export function letterSpacing(token: Token) {
+export function letterSpacing(token: Pick<Token, "tracking" | "fontSize">) {
 	return `${numberToString(token.tracking / token.fontSize)}rem`
 }


### PR DESCRIPTION
Limit the letterSpacing function parameter to only "tracking" and
"fontSize" properties from the Token type. This change improves type
safety and clarifies the function's dependencies by explicitly
specifying the required fields.