### PR TITLE
chore: add "type": "module" to package.json

### DIFF
--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/package.json",
 	"name": "oxlint-config",
+	"type": "module",
 	"private": true,
 	"exports": "./oxlintrc.json"
 }


### PR DESCRIPTION
Specify the package as an ES module by adding the "type" field
to package.json. This change ensures proper module resolution and
compatibility with ES module syntax in the package.