### PR TITLE
chore: add pnpm dedupe to Renovate post update options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,6 @@
 			"automerge": false
 		}
 	],
+	"postUpdateOptions": "pnpmDedupe",
 	"automergeType": "branch"
 }


### PR DESCRIPTION
Include "pnDedupe in postUpdateOptions to optimize package
dependencies after updates. This helps reduce duplicate packages
and keeps the lockfile cleaner.