### PR TITLE
fix(config): update postUpdateOptions to use array format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,6 @@
 			"automerge": false
 		}
 	],
-	"postUpdateOptions": "pnpmDedupe",
+	"postUpdateOptions": ["pnpmDedupe"],
 	"automergeType": "branch"
 }


### PR DESCRIPTION
Change postUpdateOptions from a string to an array to align with
expected configuration format. This ensures compatibility with
renovate's processing and prevents potential errors during updates.