### PR TITLE
chore(workspace): add pnpm-workspace.yaml to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 **/gql
 pnpm-lock.yaml
+pnpm-workspace.yaml
 worker-configuration.d.ts
 eslint-typegen.d.ts
 **/.react-router


### PR DESCRIPTION
Add pnpm-workspace.yaml to .prettierignore so the workspace
manifest is not formatted by Prettier. This prevents accidental
style changes to the pnpm workspace file and keeps the lockfile
and workspace config out of Prettier's scope.