### PR TITLE
chore: rename packages and scope Turbo build to web package

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build packages
-        run: pnpm exec turbo --filter=storybook^... build
+        run: pnpm exec turbo --filter=@anitrove/storybook^... build
 
       - name: Publish to Chromatic
         uses: chromaui/action@latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build
-        run: pnpm exec turbo web#build
+        run: pnpm exec turbo --filter=@anitrove/web build
 
       - name: Create Sentry release
         uses: getsentry/action-release@v3
@@ -75,7 +75,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build
-        run: pnpm exec turbo web#build
+        run: pnpm exec turbo --filter=@anitrove/web build
 
       - name: Deploy
         run: pnpm exec wrangler pages deploy --branch=${{ github.head_ref || github.ref_name  }}

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package.json",
-	"name": "storybook",
+	"name": "@anitrove/storybook",
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package.json",
-	"name": "web",
+	"name": "@anitrove/web",
 	"private": true,
 	"version": "0.0.0",
 	"sideEffects": false,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: "pnpm exec turbo web#start",
+		command: "pnpm exec turbo --filter=@anitrove/web start",
 		url: "http://localhost:3000",
 		reuseExistingServer: !process.env.CI,
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package.json",
-	"name": "animini",
+	"name": "anitrove",
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",


### PR DESCRIPTION
Update package names to scoped identifiers (@anitrove/*) and rename root
package to anitrove for consistency across the monorepo. This includes
apps/web -> @anitrove/web and apps/storybook -> @anitrove/storybook.

Adjust CI workflow (deploy.yml) to target the web package explicitly
when running Turbo build by using --filter=@anitrove/web build instead
of the ambiguous web#build task. This ensures the correct package is
built in both deploy jobs and avoids potential task resolution issues.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #778 
- <kbd>&nbsp;1&nbsp;</kbd> #777 👈 
<!-- GitButler Footer Boundary Bottom -->

