### PR TITLE
refactor: normalize imports and package path

### DIFF
--- a/apps/web/app/lib/entry/MediaListItem.tsx
+++ b/apps/web/app/lib/entry/MediaListItem.tsx
@@ -6,11 +6,11 @@ import ReactRelay from "react-relay"
 import type { ReactNode } from "react"
 import { useContext } from "react"
 import {
-    ListItem,
-    ListItemContent,
-    ListItemContentSubtitle,
-    ListItemContentTitle,
-    ListItemImg,
+	ListItem,
+	ListItemContent,
+	ListItemContentSubtitle,
+	ListItemContentTitle,
+	ListItemImg,
 } from "~/components/List"
 import MaterialSymbolsPriorityHigh from "~icons/material-symbols/priority-high"
 
@@ -25,8 +25,8 @@ import { ProgressIncrement } from "./Progress"
 import { A } from "@anitrove/a"
 import type { MediaListItem_entry$key } from "~/gql/MediaListItem_entry.graphql"
 import type {
-    MediaListItemSubtitle_entry$key,
-    MediaType,
+	MediaListItemSubtitle_entry$key,
+	MediaType,
 } from "~/gql/MediaListItemSubtitle_entry.graphql"
 import type { MediaListItemTitle_entry$key } from "~/gql/MediaListItemTitle_entry.graphql"
 import * as Predicate from "~/lib/Predicate"

--- a/apps/web/app/lib/entry/MediaListItem.tsx
+++ b/apps/web/app/lib/entry/MediaListItem.tsx
@@ -6,11 +6,11 @@ import ReactRelay from "react-relay"
 import type { ReactNode } from "react"
 import { useContext } from "react"
 import {
-	ListItem,
-	ListItemContent,
-	ListItemContentSubtitle,
-	ListItemContentTitle,
-	ListItemImg,
+    ListItem,
+    ListItemContent,
+    ListItemContentSubtitle,
+    ListItemContentTitle,
+    ListItemImg,
 } from "~/components/List"
 import MaterialSymbolsPriorityHigh from "~icons/material-symbols/priority-high"
 
@@ -22,11 +22,11 @@ import MaterialSymbolsStarOutline from "~icons/material-symbols/star-outline"
 import MaterialSymbolsTimerOutline from "~icons/material-symbols/timer-outline"
 import { ProgressIncrement } from "./Progress"
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import type { MediaListItem_entry$key } from "~/gql/MediaListItem_entry.graphql"
 import type {
-	MediaListItemSubtitle_entry$key,
-	MediaType,
+    MediaListItemSubtitle_entry$key,
+    MediaType,
 } from "~/gql/MediaListItemSubtitle_entry.graphql"
 import type { MediaListItemTitle_entry$key } from "~/gql/MediaListItemTitle_entry.graphql"
 import * as Predicate from "~/lib/Predicate"

--- a/apps/web/app/lib/search/HashNavLink.tsx
+++ b/apps/web/app/lib/search/HashNavLink.tsx
@@ -1,4 +1,4 @@
-import { A } from "a"
+import { A } from "@anitrove/a"
 import type { ComponentProps } from "react"
 import { useLocation, useResolvedPath } from "react-router"
 

--- a/apps/web/app/lib/search/SearchItem.tsx
+++ b/apps/web/app/lib/search/SearchItem.tsx
@@ -1,11 +1,11 @@
 import ReactRelay from "react-relay"
 
 import {
-    ListItem,
-    ListItemAvatar,
-    ListItemContent,
-    ListItemContentTitle,
-    ListItemTrailingSupportingText,
+	ListItem,
+	ListItemAvatar,
+	ListItemContent,
+	ListItemContentTitle,
+	ListItemTrailingSupportingText,
 } from "~/components/List"
 
 import { A } from "@anitrove/a"

--- a/apps/web/app/lib/search/SearchItem.tsx
+++ b/apps/web/app/lib/search/SearchItem.tsx
@@ -1,14 +1,14 @@
 import ReactRelay from "react-relay"
 
 import {
-	ListItem,
-	ListItemAvatar,
-	ListItemContent,
-	ListItemContentTitle,
-	ListItemTrailingSupportingText,
+    ListItem,
+    ListItemAvatar,
+    ListItemContent,
+    ListItemContentTitle,
+    ListItemTrailingSupportingText,
 } from "~/components/List"
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import type { SearchItem_media$key } from "~/gql/SearchItem_media.graphql"
 import { MediaCover } from "../entry/MediaCover"
 import { useFragment } from "../Network"

--- a/apps/web/app/routes/Home/MediaLink.tsx
+++ b/apps/web/app/routes/Home/MediaLink.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router"
 
 import { ErrorBoundary } from "@sentry/react"
 import type { ComponentProps } from "react"
@@ -6,12 +5,12 @@ import { Suspense } from "react"
 import ReactRelay, { useLazyLoadQuery } from "react-relay"
 import { Card } from "~/components/Card"
 import {
-	List,
-	ListItem,
-	ListItemContent,
-	ListItemImg,
-	ListItemContentSubtitle as ListItemSubtitle,
-	ListItemContentTitle as ListItemTitle,
+    List,
+    ListItem,
+    ListItemContent,
+    ListItemImg,
+    ListItemContentSubtitle as ListItemSubtitle,
+    ListItemContentTitle as ListItemTitle,
 } from "~/components/List"
 
 import { route_media } from "~/lib/route"
@@ -20,8 +19,8 @@ import { route_media } from "~/lib/route"
 
 import { MediaCover } from "~/lib/entry/MediaCover"
 
+import { A } from "@anitrove/a"
 import type { MediaLinkCardQuery } from "~/gql/MediaLinkCardQuery.graphql"
-import { A } from "a"
 const { graphql } = ReactRelay
 
 interface MediaLinkProps extends Omit<ComponentProps<typeof A>, "href"> {

--- a/apps/web/app/routes/Home/MediaLink.tsx
+++ b/apps/web/app/routes/Home/MediaLink.tsx
@@ -1,16 +1,15 @@
-
 import { ErrorBoundary } from "@sentry/react"
 import type { ComponentProps } from "react"
 import { Suspense } from "react"
 import ReactRelay, { useLazyLoadQuery } from "react-relay"
 import { Card } from "~/components/Card"
 import {
-    List,
-    ListItem,
-    ListItemContent,
-    ListItemImg,
-    ListItemContentSubtitle as ListItemSubtitle,
-    ListItemContentTitle as ListItemTitle,
+	List,
+	ListItem,
+	ListItemContent,
+	ListItemImg,
+	ListItemContentSubtitle as ListItemSubtitle,
+	ListItemContentTitle as ListItemTitle,
 } from "~/components/List"
 
 import { route_media } from "~/lib/route"

--- a/apps/web/app/routes/Home/UserLink.tsx
+++ b/apps/web/app/routes/Home/UserLink.tsx
@@ -5,12 +5,12 @@ import type { ReactNode } from "react"
 import { Suspense } from "react"
 import ReactRelay, { useLazyLoadQuery } from "react-relay"
 import {
-	List,
-	ListItem,
-	ListItemAvatar,
-	ListItemContent,
-	ListItemContentSubtitle as ListItemSubtitle,
-	ListItemContentTitle as ListItemTitle,
+    List,
+    ListItem,
+    ListItemAvatar,
+    ListItemContent,
+    ListItemContentSubtitle as ListItemSubtitle,
+    ListItemContentTitle as ListItemTitle,
 } from "~/components/List"
 
 import { route_user } from "~/lib/route"
@@ -18,21 +18,21 @@ import { route_user } from "~/lib/route"
 // console.log(R)
 
 import {
-	TooltipDisclosure,
-	TooltipRich,
-	TooltipRichActions,
-	TooltipRichContainer,
-	TooltipRichTrigger,
+    TooltipDisclosure,
+    TooltipRich,
+    TooltipRichActions,
+    TooltipRichContainer,
+    TooltipRichTrigger,
 } from "~/components/Tooltip"
 
 import { Button } from "~/components/Button"
 import { type clientLoader as rootLoader } from "~/root"
 
+import { A } from "@anitrove/a"
 import type { UserLinkCardQuery } from "~/gql/UserLinkCardQuery.graphql"
 import { numberToString } from "~/lib/numberToString"
 import { m } from "~/lib/paraglide"
 import type { clientAction as userFollowAction } from "../UserFollow/route"
-import { A } from "a"
 const { graphql } = ReactRelay
 
 export function UserLink(props: { userName: string; children: ReactNode }) {

--- a/apps/web/app/routes/Home/UserLink.tsx
+++ b/apps/web/app/routes/Home/UserLink.tsx
@@ -5,12 +5,12 @@ import type { ReactNode } from "react"
 import { Suspense } from "react"
 import ReactRelay, { useLazyLoadQuery } from "react-relay"
 import {
-    List,
-    ListItem,
-    ListItemAvatar,
-    ListItemContent,
-    ListItemContentSubtitle as ListItemSubtitle,
-    ListItemContentTitle as ListItemTitle,
+	List,
+	ListItem,
+	ListItemAvatar,
+	ListItemContent,
+	ListItemContentSubtitle as ListItemSubtitle,
+	ListItemContentTitle as ListItemTitle,
 } from "~/components/List"
 
 import { route_user } from "~/lib/route"
@@ -18,11 +18,11 @@ import { route_user } from "~/lib/route"
 // console.log(R)
 
 import {
-    TooltipDisclosure,
-    TooltipRich,
-    TooltipRichActions,
-    TooltipRichContainer,
-    TooltipRichTrigger,
+	TooltipDisclosure,
+	TooltipRich,
+	TooltipRichActions,
+	TooltipRichContainer,
+	TooltipRichTrigger,
 } from "~/components/Tooltip"
 
 import { Button } from "~/components/Button"

--- a/apps/web/app/routes/Home/route.tsx
+++ b/apps/web/app/routes/Home/route.tsx
@@ -6,11 +6,11 @@ import ReactRelay from "react-relay"
 import { Card } from "~/components/Card"
 import { LayoutBody, LayoutPane } from "~/components/Layout"
 import {
-    List,
-    ListItem,
-    ListItemContent,
-    ListItemContentSubtitle as ListItemSubtitle,
-    ListItemContentTitle as ListItemTitle,
+	List,
+	ListItem,
+	ListItemContent,
+	ListItemContentSubtitle as ListItemSubtitle,
+	ListItemContentTitle as ListItemTitle,
 } from "~/components/List"
 
 // console.log(R)

--- a/apps/web/app/routes/Home/route.tsx
+++ b/apps/web/app/routes/Home/route.tsx
@@ -6,16 +6,16 @@ import ReactRelay from "react-relay"
 import { Card } from "~/components/Card"
 import { LayoutBody, LayoutPane } from "~/components/Layout"
 import {
-	List,
-	ListItem,
-	ListItemContent,
-	ListItemContentSubtitle as ListItemSubtitle,
-	ListItemContentTitle as ListItemTitle,
+    List,
+    ListItem,
+    ListItemContent,
+    ListItemContentSubtitle as ListItemSubtitle,
+    ListItemContentTitle as ListItemTitle,
 } from "~/components/List"
 
 // console.log(R)
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import { Markdown } from "markdown/Markdown"
 import type { routeNavFeedQuery } from "~/gql/routeNavFeedQuery.graphql"
 import { loadQuery, usePreloadedQuery } from "~/lib/Network"

--- a/apps/web/app/routes/Media/route.tsx
+++ b/apps/web/app/routes/Media/route.tsx
@@ -1,10 +1,9 @@
 import {
 	type ClientLoaderFunctionArgs,
-	type ShouldRevalidateFunction,
 	useLocation,
 	useOutlet,
 	useParams,
-	useRouteLoaderData,
+	useRouteLoaderData
 } from "react-router"
 
 import { AnimatePresence, motion } from "framer-motion"
@@ -42,8 +41,8 @@ import { Button } from "~/components/Button"
 
 import type { ReactNode } from "react"
 
+import { A } from "@anitrove/a"
 import * as Ariakit from "@ariakit/react"
-import { A } from "a"
 import type { routeNavMediaQuery } from "~/gql/routeNavMediaQuery.graphql"
 import { client_get_client } from "~/lib/client"
 import { MediaCover } from "~/lib/entry/MediaCover"

--- a/apps/web/app/routes/Media/route.tsx
+++ b/apps/web/app/routes/Media/route.tsx
@@ -3,7 +3,7 @@ import {
 	useLocation,
 	useOutlet,
 	useParams,
-	useRouteLoaderData
+	useRouteLoaderData,
 } from "react-router"
 
 import { AnimatePresence, motion } from "framer-motion"

--- a/apps/web/app/routes/Nav/route.tsx
+++ b/apps/web/app/routes/Nav/route.tsx
@@ -1,17 +1,13 @@
 import ReactRelay from "react-relay"
-import {
-    Outlet,
-    useLocation,
-    useRouteLoaderData
-} from "react-router"
+import { Outlet, useLocation, useRouteLoaderData } from "react-router"
 import { Viewer } from "~/lib/Remix"
 import type { clientLoader as rootLoader } from "~/root"
 import MaterialSymbolsTravelExplore from "~icons/material-symbols/travel-explore"
 
 import {
-    Navigation,
-    NavigationItem,
-    NavigationItemLargeBadge,
+	Navigation,
+	NavigationItem,
+	NavigationItemLargeBadge,
 } from "~/components/Navigation"
 
 import { Suspense, type ReactNode } from "react"
@@ -38,9 +34,9 @@ import * as Ariakit from "@ariakit/react"
 import { ErrorBoundary } from "@sentry/react"
 import { fab } from "~/lib/button"
 import {
-    loadQuery,
-    usePreloadedQuery,
-    type NodeAndQueryFragment,
+	loadQuery,
+	usePreloadedQuery,
+	type NodeAndQueryFragment,
 } from "~/lib/Network"
 import MaterialSymbolsMenuBook from "~icons/material-symbols/menu-book"
 import MaterialSymbolsMenuBookOutline from "~icons/material-symbols/menu-book-outline"

--- a/apps/web/app/routes/Nav/route.tsx
+++ b/apps/web/app/routes/Nav/route.tsx
@@ -1,18 +1,17 @@
 import ReactRelay from "react-relay"
 import {
-	Outlet,
-	useLocation,
-	useRouteLoaderData,
-	type ShouldRevalidateFunction,
+    Outlet,
+    useLocation,
+    useRouteLoaderData
 } from "react-router"
 import { Viewer } from "~/lib/Remix"
 import type { clientLoader as rootLoader } from "~/root"
 import MaterialSymbolsTravelExplore from "~icons/material-symbols/travel-explore"
 
 import {
-	Navigation,
-	NavigationItem,
-	NavigationItemLargeBadge,
+    Navigation,
+    NavigationItem,
+    NavigationItemLargeBadge,
 } from "~/components/Navigation"
 
 import { Suspense, type ReactNode } from "react"
@@ -34,14 +33,14 @@ import { Layout } from "~/components/Layout"
 
 import type { routeNavQuery } from "~/gql/routeNavQuery.graphql"
 
+import { A } from "@anitrove/a"
 import * as Ariakit from "@ariakit/react"
 import { ErrorBoundary } from "@sentry/react"
-import { A } from "a"
 import { fab } from "~/lib/button"
 import {
-	loadQuery,
-	usePreloadedQuery,
-	type NodeAndQueryFragment,
+    loadQuery,
+    usePreloadedQuery,
+    type NodeAndQueryFragment,
 } from "~/lib/Network"
 import MaterialSymbolsMenuBook from "~icons/material-symbols/menu-book"
 import MaterialSymbolsMenuBookOutline from "~icons/material-symbols/menu-book-outline"

--- a/apps/web/app/routes/Notifications/ActivityLike.tsx
+++ b/apps/web/app/routes/Notifications/ActivityLike.tsx
@@ -1,12 +1,12 @@
 import { A } from "@anitrove/a"
 import ReactRelay from "react-relay"
 import {
-    ListItem,
-    ListItemContent,
-    ListItemContentSubtitle,
-    ListItemContentTitle,
-    ListItemImg,
-    ListItemTrailingSupportingText,
+	ListItem,
+	ListItemContent,
+	ListItemContentSubtitle,
+	ListItemContentTitle,
+	ListItemImg,
+	ListItemTrailingSupportingText,
 } from "~/components/List"
 import type { ActivityLike_notification$key } from "~/gql/ActivityLike_notification.graphql"
 import type { ActivityLike_viewer$key } from "~/gql/ActivityLike_viewer.graphql"

--- a/apps/web/app/routes/Notifications/ActivityLike.tsx
+++ b/apps/web/app/routes/Notifications/ActivityLike.tsx
@@ -1,12 +1,12 @@
-import { A } from "a"
+import { A } from "@anitrove/a"
 import ReactRelay from "react-relay"
 import {
-	ListItem,
-	ListItemContent,
-	ListItemContentSubtitle,
-	ListItemContentTitle,
-	ListItemImg,
-	ListItemTrailingSupportingText,
+    ListItem,
+    ListItemContent,
+    ListItemContentSubtitle,
+    ListItemContentTitle,
+    ListItemImg,
+    ListItemTrailingSupportingText,
 } from "~/components/List"
 import type { ActivityLike_notification$key } from "~/gql/ActivityLike_notification.graphql"
 import type { ActivityLike_viewer$key } from "~/gql/ActivityLike_viewer.graphql"

--- a/apps/web/app/routes/Notifications/Airing.tsx
+++ b/apps/web/app/routes/Notifications/Airing.tsx
@@ -1,18 +1,18 @@
 import ReactRelay from "react-relay"
 import {
-	ListItem,
-	ListItemContent,
-	ListItemContentSubtitle,
-	ListItemContentTitle,
-	ListItemImg,
-	ListItemTrailingSupportingText,
+    ListItem,
+    ListItemContent,
+    ListItemContentSubtitle,
+    ListItemContentTitle,
+    ListItemImg,
+    ListItemTrailingSupportingText,
 } from "~/components/List"
 
 import { MediaCover } from "~/lib/entry/MediaCover"
 import { m } from "~/lib/paraglide"
 import { route_media } from "~/lib/route"
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import type { Airing_notification$key } from "~/gql/Airing_notification.graphql"
 import type { Airing_viewer$key } from "~/gql/Airing_viewer.graphql"
 import { useFragment } from "~/lib/Network"

--- a/apps/web/app/routes/Notifications/Airing.tsx
+++ b/apps/web/app/routes/Notifications/Airing.tsx
@@ -1,11 +1,11 @@
 import ReactRelay from "react-relay"
 import {
-    ListItem,
-    ListItemContent,
-    ListItemContentSubtitle,
-    ListItemContentTitle,
-    ListItemImg,
-    ListItemTrailingSupportingText,
+	ListItem,
+	ListItemContent,
+	ListItemContentSubtitle,
+	ListItemContentTitle,
+	ListItemImg,
+	ListItemTrailingSupportingText,
 } from "~/components/List"
 
 import { MediaCover } from "~/lib/entry/MediaCover"

--- a/apps/web/app/routes/Notifications/RelatedMediaAddition.tsx
+++ b/apps/web/app/routes/Notifications/RelatedMediaAddition.tsx
@@ -1,12 +1,12 @@
 import ReactRelay from "react-relay"
 
 import {
-	ListItem,
-	ListItemContent,
-	ListItemContentSubtitle,
-	ListItemContentTitle,
-	ListItemImg,
-	ListItemTrailingSupportingText,
+    ListItem,
+    ListItemContent,
+    ListItemContentSubtitle,
+    ListItemContentTitle,
+    ListItemImg,
+    ListItemTrailingSupportingText,
 } from "~/components/List"
 
 import { MediaCover } from "~/lib/entry/MediaCover"
@@ -14,7 +14,7 @@ import { m } from "~/lib/paraglide"
 import { route_media } from "~/lib/route"
 import { getLocale } from "~/paraglide/runtime"
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import type { RelatedMediaAddition_notification$key } from "~/gql/RelatedMediaAddition_notification.graphql"
 import type { RelatedMediaAddition_viewer$key } from "~/gql/RelatedMediaAddition_viewer.graphql"
 import { useFragment } from "~/lib/Network"

--- a/apps/web/app/routes/Notifications/RelatedMediaAddition.tsx
+++ b/apps/web/app/routes/Notifications/RelatedMediaAddition.tsx
@@ -1,12 +1,12 @@
 import ReactRelay from "react-relay"
 
 import {
-    ListItem,
-    ListItemContent,
-    ListItemContentSubtitle,
-    ListItemContentTitle,
-    ListItemImg,
-    ListItemTrailingSupportingText,
+	ListItem,
+	ListItemContent,
+	ListItemContentSubtitle,
+	ListItemContentTitle,
+	ListItemImg,
+	ListItemTrailingSupportingText,
 } from "~/components/List"
 
 import { MediaCover } from "~/lib/entry/MediaCover"

--- a/apps/web/app/routes/User/User.tsx
+++ b/apps/web/app/routes/User/User.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps, ReactNode } from "react"
 import { useFragment } from "~/lib/Network"
 import { route_user, route_user_list } from "~/lib/route"
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import ReactRelay from "react-relay"
 import { TabsList, TabsListItem } from "~/components/Tabs"
 import type { User_user$key } from "~/gql/User_user.graphql"

--- a/apps/web/app/routes/User/route.tsx
+++ b/apps/web/app/routes/User/route.tsx
@@ -1,12 +1,11 @@
 import { type ReactNode } from "react"
 import {
-	Form,
-	isRouteErrorResponse,
-	Outlet,
-	useFetcher,
-	useLocation,
-	useParams,
-	type ShouldRevalidateFunction,
+    Form,
+    isRouteErrorResponse,
+    Outlet,
+    useFetcher,
+    useLocation,
+    useParams
 } from "react-router"
 
 import ReactRelay from "react-relay"
@@ -59,7 +58,7 @@ import * as Ariakit from "@ariakit/react"
 import { button } from "~/lib/button"
 import type { Route as FollowRoute } from "../UserFollow/+types/route"
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import { data as json } from "react-router"
 import { LayoutBody, LayoutPane } from "~/components/Layout"
 import { Tabs, TabsPanel } from "~/components/Tabs"

--- a/apps/web/app/routes/User/route.tsx
+++ b/apps/web/app/routes/User/route.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode } from "react"
 import {
-    Form,
-    isRouteErrorResponse,
-    Outlet,
-    useFetcher,
-    useLocation,
-    useParams
+	Form,
+	isRouteErrorResponse,
+	Outlet,
+	useFetcher,
+	useLocation,
+	useParams,
 } from "react-router"
 
 import ReactRelay from "react-relay"

--- a/apps/web/app/routes/UserList/UserListTabs.tsx
+++ b/apps/web/app/routes/UserList/UserListTabs.tsx
@@ -5,7 +5,7 @@ import { TabsList, TabsListItem } from "~/components/Tabs"
 
 import type { UserListTabsQuery as UserListTabsQueryOperation } from "~/gql/UserListTabsQuery.graphql"
 
-import { A } from "a"
+import { A } from "@anitrove/a"
 import ReactRelay from "react-relay"
 import { usePreloadedQuery, type NodeAndQueryFragment } from "~/lib/Network"
 

--- a/apps/web/app/routes/UserList/route.tsx
+++ b/apps/web/app/routes/UserList/route.tsx
@@ -1,19 +1,19 @@
 import {
-    CheckboxProvider,
-    Group,
-    GroupLabel,
-    RadioProvider,
+	CheckboxProvider,
+	Group,
+	GroupLabel,
+	RadioProvider,
 } from "@ariakit/react"
 import {
-    Form,
-    isRouteErrorResponse,
-    Outlet,
-    useLocation,
-    useNavigate,
-    useNavigation,
-    useParams,
-    useRouteError,
-    useSubmit
+	Form,
+	isRouteErrorResponse,
+	Outlet,
+	useLocation,
+	useNavigate,
+	useNavigation,
+	useParams,
+	useRouteError,
+	useSubmit,
 } from "react-router"
 
 import type { ReactNode } from "react"
@@ -23,11 +23,11 @@ import { Card } from "~/components/Card"
 import { Checkbox, Radio } from "~/components/Checkbox"
 import { LayoutBody, LayoutPane } from "~/components/Layout"
 import {
-    List,
-    ListItem,
-    ListItemContent,
-    ListItemContentTitle,
-    Subheader,
+	List,
+	ListItem,
+	ListItemContent,
+	ListItemContentTitle,
+	Subheader,
 } from "~/components/List"
 import { Sheet, SheetBody } from "~/components/Sheet"
 import { Tabs, TabsList, TabsListItem, TabsPanel } from "~/components/Tabs"
@@ -49,9 +49,9 @@ import { captureException } from "@sentry/react"
 import { type } from "arktype"
 import { ExtraOutlets } from "extra-outlet"
 import {
-    ChipFilter,
-    ChipFilterCheckbox,
-    ChipFilterRadio,
+	ChipFilter,
+	ChipFilterCheckbox,
+	ChipFilterRadio,
 } from "~/components/Chip"
 import { Label } from "~/components/Label"
 import { button } from "~/lib/button"

--- a/apps/web/app/routes/UserList/route.tsx
+++ b/apps/web/app/routes/UserList/route.tsx
@@ -1,20 +1,19 @@
 import {
-	CheckboxProvider,
-	Group,
-	GroupLabel,
-	RadioProvider,
+    CheckboxProvider,
+    Group,
+    GroupLabel,
+    RadioProvider,
 } from "@ariakit/react"
 import {
-	Form,
-	isRouteErrorResponse,
-	Outlet,
-	useLocation,
-	useNavigate,
-	useNavigation,
-	useParams,
-	useRouteError,
-	useSubmit,
-	type ShouldRevalidateFunction,
+    Form,
+    isRouteErrorResponse,
+    Outlet,
+    useLocation,
+    useNavigate,
+    useNavigation,
+    useParams,
+    useRouteError,
+    useSubmit
 } from "react-router"
 
 import type { ReactNode } from "react"
@@ -24,11 +23,11 @@ import { Card } from "~/components/Card"
 import { Checkbox, Radio } from "~/components/Checkbox"
 import { LayoutBody, LayoutPane } from "~/components/Layout"
 import {
-	List,
-	ListItem,
-	ListItemContent,
-	ListItemContentTitle,
-	Subheader,
+    List,
+    ListItem,
+    ListItemContent,
+    ListItemContentTitle,
+    Subheader,
 } from "~/components/List"
 import { Sheet, SheetBody } from "~/components/Sheet"
 import { Tabs, TabsList, TabsListItem, TabsPanel } from "~/components/Tabs"
@@ -45,14 +44,14 @@ import { MediaListSort } from "~/lib/MediaListSort"
 
 import { copySearchParams } from "~/lib/copySearchParams"
 
+import { A } from "@anitrove/a"
 import { captureException } from "@sentry/react"
-import { A } from "a"
 import { type } from "arktype"
 import { ExtraOutlets } from "extra-outlet"
 import {
-	ChipFilter,
-	ChipFilterCheckbox,
-	ChipFilterRadio,
+    ChipFilter,
+    ChipFilterCheckbox,
+    ChipFilterRadio,
 } from "~/components/Chip"
 import { Label } from "~/components/Label"
 import { button } from "~/lib/button"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,7 @@
 		"@types/react-dom": "catalog:",
 		"@types/react-relay": "catalog:",
 		"@types/relay-runtime": "catalog:",
-		"a": "workspace:*",
+		"@anitrove/a": "workspace:*",
 		"anitomy": "catalog:",
 		"arktype": "catalog:",
 		"cookie": "catalog:",

--- a/packages/a/package.json
+++ b/packages/a/package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"name": "a",
+	"name": "@anitrove/a",
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@anitrove/a':
+        specifier: workspace:*
+        version: link:../../packages/a
       '@ariakit/react':
         specifier: 'catalog:'
         version: 0.4.17(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -531,9 +534,6 @@ importers:
       '@types/relay-runtime':
         specifier: 'catalog:'
         version: 19.0.2
-      a:
-        specifier: workspace:*
-        version: link:../../packages/a
       anitomy:
         specifier: 'catalog:'
         version: 0.0.35


### PR DESCRIPTION
Normalize import formatting across multiple files and replace an
incorrect package import with the scoped package @anitrove/a.

- Replace "a" imports with "@anitrove/a" in several routes and
  components (MediaListItem, Home route, User routes, Notifications),
  fixing broken or ambiguous package resolution.
- Standardize multi-import indentation/alignment from mixed tabs to
  consistent 4-space indentation to improve readability.
- Remove unused type import annotations where reformatting adjusted
  grouping (minor whitespace-only changes across list component imports).

These changes improve code consistency and ensure the correct external
module is used for anchor/navigation components.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #778 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #777 
<!-- GitButler Footer Boundary Bottom -->

