### PR TITLE
chore: ignore generated reports directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ storybook-static
 **/eslint-typegen.d.ts
 # stryker temp files
 .stryker-tmp
+reports


### PR DESCRIPTION
Add "reports" to .gitignore so generated report files are not tracked.
This prevents build or test artifacts from being committed accidentally 
and keeps the repository clean from environment-specific output.