### PR TITLE
refactor: rename unstyled package to @anitrove/unstyled

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -17,7 +17,7 @@
 		"load-assets": "workspace:*",
 		"m3-react": "workspace:*",
 		"markdown": "workspace:*",
-		"unstyled": "workspace:*"
+		"@anitrove/unstyled": "workspace:*"
 	},
 	"devDependencies": {
 		"@chromatic-com/storybook": "catalog:",

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { fn } from "storybook/test"
 
+import { useStyles } from "@anitrove/unstyled"
 import { button } from "m3-react/button"
 import type { ComponentProps } from "react"
-import { useStyles } from "unstyled"
 
 interface ButtonProps extends ComponentProps<"button"> {
 	size?: "xs" | "sm" | "md" | "lg" | "xl"

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -16,7 +16,7 @@
 		"check": "tsc --noEmit"
 	},
 	"peerDependencies": {
-		"unstyled": "workspace:*"
+		"@anitrove/unstyled": "workspace:*"
 	},
 	"devDependencies": {
 		"eslint": "catalog:",

--- a/packages/design/src/design-tokens.ts
+++ b/packages/design/src/design-tokens.ts
@@ -1,4 +1,4 @@
-import { type Properties, type RawStyles } from "unstyled"
+import { type Properties, type RawStyles } from "@anitrove/unstyled"
 
 import type Colors from "./design-colors"
 import fonts, { letterSpacing, pxToRem } from "./design-fonts"

--- a/packages/design/src/design.ts
+++ b/packages/design/src/design.ts
@@ -1,5 +1,5 @@
 import { numberToString } from "utilities"
-import { type Value, mapValue } from "unstyled/value"
+import { type Value, mapValue } from "@anitrove/unstyled/value"
 export * as utilities from "./design-utilities"
 export * as tokens from "./design-tokens"
 

--- a/packages/m3-react/package.json
+++ b/packages/m3-react/package.json
@@ -26,6 +26,6 @@
 		"@anitrove/design": "workspace:*"
 	},
 	"peerDependencies": {
-		"unstyled": "workspace:*"
+		"@anitrove/unstyled": "workspace:*"
 	}
 }

--- a/packages/m3-react/src/m3-react-button.bench.tsx
+++ b/packages/m3-react/src/m3-react-button.bench.tsx
@@ -1,7 +1,6 @@
-import { describe } from "vitest"
-import { bench } from "vitest"
+import { cva } from "@anitrove/unstyled"
+import { bench, describe } from "vitest"
 import { buttonDefinition } from "./m3-react-button"
-import { cva } from "unstyled"
 
 describe("cva", () => {
 	bench("button", () => {

--- a/packages/m3-react/src/m3-react-button.spec.tsx
+++ b/packages/m3-react/src/m3-react-button.spec.tsx
@@ -1,4 +1,4 @@
-import { print } from "unstyled"
+import { print } from "@anitrove/unstyled"
 import { describe, expect, it } from "vitest"
 import { button } from "./m3-react-button"
 

--- a/packages/m3-react/src/m3-react-button.tsx
+++ b/packages/m3-react/src/m3-react-button.tsx
@@ -1,6 +1,6 @@
 import * as design from "@anitrove/design"
 import { media } from "@anitrove/design"
-import { cva, defineCva } from "unstyled"
+import { cva, defineCva } from "@anitrove/unstyled"
 
 export const buttonDefinition = defineCva({
 	base: {

--- a/packages/unstyled/package.json
+++ b/packages/unstyled/package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"name": "unstyled",
+	"name": "@anitrove/unstyled",
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       '@anitrove/design':
         specifier: workspace:*
         version: link:../../packages/design
+      '@anitrove/unstyled':
+        specifier: workspace:*
+        version: link:../../packages/unstyled
       load-assets:
         specifier: workspace:*
         version: link:../../packages/load-assets
@@ -404,9 +407,6 @@ importers:
       markdown:
         specifier: workspace:*
         version: link:../../packages/markdown
-      unstyled:
-        specifier: workspace:*
-        version: link:../../packages/unstyled
     devDependencies:
       '@chromatic-com/storybook':
         specifier: 'catalog:'
@@ -713,7 +713,7 @@ importers:
 
   packages/design:
     dependencies:
-      unstyled:
+      '@anitrove/unstyled':
         specifier: workspace:*
         version: link:../unstyled
     devDependencies:
@@ -958,7 +958,7 @@ importers:
       '@anitrove/design':
         specifier: workspace:*
         version: link:../design
-      unstyled:
+      '@anitrove/unstyled':
         specifier: workspace:*
         version: link:../unstyled
     devDependencies:


### PR DESCRIPTION
- Replace bare "unstyled" imports with "@anitrove/unstyled" in:
  - storybook Button story
  - m3-react sources and tests (button, bench)
  - design tokens
- Update package.json entries and peerDependencies:
  - packages/unstyled -> name "@anitrove/unstyled"
  - replace workspace dependency "unstyled" with "@anitrove/unstyled"
  - update peerDependencies in design and m3-react packages
- Reorder vitest imports in bench file and adjust import locations