### PR TITLE
chore(scripts): simplify bench script to run all benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,49 @@
+name: CodSpeed
+
+on:
+  push:
+    branches:
+      - master
+      - renovate/**
+  pull_request:
+  # merge_group: # codespeed does not support merge groups
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  TURBO_CACHE: remote:rw
+  TURBO_SCM_BASE: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha || github.event.before }}
+
+concurrency:
+  group: deploy-${{ github.workflow }}-${{ github.ref_name != 'master' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    name: Benchmark
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: "pnpm"
+
+      - name: Install dependencies 📦
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          run: pnpm exec turbo bench

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,34 +82,6 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
-  bench:
-    runs-on: ubuntu-latest
-    name: Benchmark
-    # codespeed does not support merge groups
-    if: github.event_name != 'merge_group'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          filter: blob:none
-          fetch-depth: 0
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: package.json
-          cache: "pnpm"
-
-      - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Run benchmarks
-        uses: CodSpeedHQ/action@v3
-        with:
-          run: pnpm exec turbo bench
-          token: ${{ secrets.CODSPEED_TOKEN }}
-
   stryker:
     runs-on: ubuntu-latest
     name: Coverage

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"eslint-typegen": "node --import=tsx eslint.config.ts",
 		"dev": "turbo watch dev",
 		"format": "prettier . -w --cache --experimental-cli",
-		"bench": "vitest bench --run --changed origin/master",
+		"bench": "vitest bench --run",
 		"test": "vitest --run --changed origin/master",
 		"test-e2e": "turbo run test-e2e --continue=dependencies-successful --log-order=stream",
 		"stryker": "stryker run --incremental",

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,7 @@
 		"//#lint": {},
 		"test-e2e": {},
 		"//#test": {},
-		"//#bench": {},
+		"//#bench": { "cache": false },
 		"//#format": {},
 		"//#knip": {},
 		"//#stryker": {


### PR DESCRIPTION
Update package.json scripts: change the vitest bench command
from running only changed benchmarks against origin/master to
running all benchmarks unconditionally.

This removes the --changed origin/master filter so benchmark runs
are comprehensive and don't rely on git history. It reduces CI/
local complexity and ensures full benchmark coverage when
executing npm run bench.