### PR TITLE
chore(ci): switch benchmark runner to vitest

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:
-          run: pnpm exec turbo bench
+          run: pnpm exec vitest bench --run


### PR DESCRIPTION
Update GitHub Actions workflow to run benchmarks withest
instead of Turbo. Replace the Cod action command from
'pnpm exec turbo' to 'pnpm exec vitest bench --run' so the CI
now executes Vitest's benchmarking runner.

This change standardizes benchmarking on Vitest, ensuring the
bench command uses the project's current test runner and its
performance features. It also avoids relying on Turbo for bench
execution, reducing tooling mismatch in CI.