### PR TITLE
chore(ci): switch benchmark runner to Vitest

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:
-          run: pnpm exec turbo bench
+          run: pnpm exec vitest bench --run


### PR DESCRIPTION
Replace CodSpeed workflow command to run Vitest benchmarks instead
of Turbo. The change updates the GitHub Actions step to execute
"pnpm exec vitest bench --run", ensuring benchmarks run with the
project's Vitest configuration and any related reporters/plugins.
This aligns benchmarking with the test runner and fixes issues with
Turbo-based bench invocation.