### PR TITLE
chore(test): run benches only for changed filesUpdate package.json scripts to limit vitest benchmark runs to

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"eslint-typegen": "node --import=tsx eslint.config.ts",
 		"dev": "turbo watch dev",
 		"format": "prettier . -w --cache --experimental-cli",
-		"bench": "vitest bench --changed origin/master",
+		"bench": "vitest bench",
 		"test": "vitest --run --changed origin/master",
 		"test-e2e": "turbo run test-e2e --continue=dependencies-successful --log-order=stream",
 		"stryker": "stryker run --incremental",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"eslint-typegen": "node --import=tsx eslint.config.ts",
 		"dev": "turbo watch dev",
 		"format": "prettier . -w --cache --experimental-cli",
-		"bench": "vitest bench --run",
+		"bench": "vitest bench --changed origin/master",
 		"test": "vitest --run --changed origin/master",
 		"test-e2e": "turbo run test-e2e --continue=dependencies-successful --log-order=stream",
 		"stryker": "stryker run --incremental",


### PR DESCRIPTION
changed files since origin/master. This replaces a full bench
run with `vitest bench --changed origin/master`, matching the
existing `test` behavior and speeding up CI/local workflows by
avoiding unnecessary full-suite benchmarks.