### PR TITLE
chore(ci): enable CodSpeed debug env for benchmarking

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -47,3 +47,5 @@ jobs:
         uses: CodSpeedHQ/action@v3
         with:
           run: pnpm exec turbo bench
+        env:
+          CODSPEED_DEBUG: 1

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,13 @@
 		"//#lint": {},
 		"test-e2e": {},
 		"//#test": {},
-		"//#bench": { "cache": false },
+		"//#bench": {
+			"cache": false,
+			"passThroughEnv": [
+				"__CODSPEED_NODE_CORE_INTROSPECTION_PATH__",
+				"CODSPEED_DEBUG"
+			]
+		},
 		"//#format": {},
 		"//#knip": {},
 		"//#stryker": {


### PR DESCRIPTION
Add CODPEED_DEBUG=1 to the CodSpeedHub Action and pass through
CodSpeed-related environment variables in turbo tasks. This ensures
benchmarks run with debug logging enabled and allows the __CODSPEED_NODE_CORE_INTROSPECTION_PATH__
and CODSPEED_DEBUG env vars to be available to the bench task when run
via Turborepo. This aids troubleshooting and consistent behavior of
performance.