### PR TITLE
chore(ci): switch auto-commit action and fix input name

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -57,6 +57,6 @@ jobs:
 
       - name: Commit changes
         if: ${{ !cancelled() }}
-        uses: stefanzweifel/git-auto-commit-action@01d77ca6cb089da1360e540865f7d035c95aa199
+        uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27
         with:
-          commit_message: "refactor: run format"
+          commit-message: "refactor: run format"


### PR DESCRIPTION
Update GitHub Actions workflow to use autofix-ci/action instead
of stefanzweifel/git-auto-commit-action for committing formatting
changes. Adjust the action input from commit_message to the
correct commit-message key expected by the new action.

This ensures the commit step runs with the supported action and
uses the proper parameter name so automated formatting commits
are created reliably.