### PR TITLE
feat: replace framer-motion imports with motion/react

### DIFF
--- a/apps/web/app/components/Sheet.tsx
+++ b/apps/web/app/components/Sheet.tsx
@@ -1,11 +1,11 @@
 import * as Ariakit from "@ariakit/react"
 import {
-	AnimatePresence,
-	animate,
-	motion,
-	useMotionValue,
-	useTransform,
-} from "framer-motion"
+    AnimatePresence,
+    animate,
+    motion,
+    useMotionValue,
+    useTransform,
+} from "motion/react"
 import type { ComponentProps, JSX, ReactNode } from "react"
 import { createContext, useContext } from "react"
 import type { VariantProps } from "tailwind-variants"

--- a/apps/web/app/components/Sheet.tsx
+++ b/apps/web/app/components/Sheet.tsx
@@ -1,10 +1,10 @@
 import * as Ariakit from "@ariakit/react"
 import {
-    AnimatePresence,
-    animate,
-    motion,
-    useMotionValue,
-    useTransform,
+	AnimatePresence,
+	animate,
+	motion,
+	useMotionValue,
+	useTransform,
 } from "motion/react"
 import type { ComponentProps, JSX, ReactNode } from "react"
 import { createContext, useContext } from "react"

--- a/apps/web/app/components/Tabs.tsx
+++ b/apps/web/app/components/Tabs.tsx
@@ -1,5 +1,5 @@
 import { useStoreState } from "@ariakit/react"
-import { motion } from "framer-motion"
+import { motion } from "motion/react"
 
 import * as Ariakit from "@ariakit/react"
 import type { ReactNode } from "react"

--- a/apps/web/app/components/Tooltip.tsx
+++ b/apps/web/app/components/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, motion } from "motion/react"
 import type { ComponentProps, PropsWithChildren, ReactNode } from "react"
 import { createContext, useContext } from "react"
 import MaterialSymbolsArrowDropDown from "~icons/material-symbols/arrow-drop-down"

--- a/apps/web/app/routes/Media/route.tsx
+++ b/apps/web/app/routes/Media/route.tsx
@@ -6,7 +6,7 @@ import {
 	useRouteLoaderData,
 } from "react-router"
 
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, motion } from "motion/react"
 
 import { useTooltipStore } from "@ariakit/react"
 import { cloneElement } from "react"

--- a/apps/web/app/routes/MediaEdit/route.tsx
+++ b/apps/web/app/routes/MediaEdit/route.tsx
@@ -19,7 +19,7 @@
 
 // import * as Ariakit from "@ariakit/react"
 
-// import { motion } from "framer-motion"
+// import { motion } from "motion/react"
 // import type { ComponentProps } from "react"
 import type { ReactNode } from "react"
 // import { createDialog } from "~/lib/dialog"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,7 +56,6 @@
 		"electron": "catalog:",
 		"electron-devtools-installer": "catalog:",
 		"extra-outlet": "workspace:*",
-		"framer-motion": "catalog:",
 		"graphql": "catalog:",
 		"hono": "catalog:",
 		"isbot": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,6 @@ catalogs:
     flubber:
       specifier: 0.4.2
       version: 0.4.2
-    framer-motion:
-      specifier: 12.23.12
-      version: 12.23.12
     graphql:
       specifier: 16.11.0
       version: 16.11.0
@@ -552,9 +549,6 @@ importers:
       extra-outlet:
         specifier: workspace:*
         version: link:../../packages/extra-outlet
-      framer-motion:
-        specifier: 'catalog:'
-        version: 12.23.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       graphql:
         specifier: 'catalog:'
         version: 16.11.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,6 @@ catalog:
   eslint-typegen: 2.3.0
   eslint-vitest-rule-tester: 2.2.1
   flubber: 0.4.2
-  framer-motion: 12.23.12
   graphql: 16.11.0
   graphql-config: 5.1.5
   hono: 4.9.2


### PR DESCRIPTION
Update various components and routes import animation helpers
from the motion/react entry point instead of framer-motion. Change
imports in Tabs, Tooltip, Sheet, Media route, and MediaEdit route
to use motion/react and adjust named imports formatting in Sheet.

Remove framer-motion from workspace and app package manifests and
prune its entries from pnpm lockfiles to reflect the dependency
removal. This cleans up unused dependency declarations and ensures
the codebase uses the new motion/react package surface.