### PR TITLE
chore: cleanup of unused catalogs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@ enable-pre-post-scripts=false
 resolution-mode=lowest-direct
 verify-deps-before-run=install
 catalog-mode=strict
+cleanup-unused-catalogs=true


### PR DESCRIPTION
Enable automatic cleanup of unused by setting the
cleanup-catalogs flag true in .rc.

This reduces clutter and prevents catalog entries
from persisting across. It complements existing
strict catalog and verification settings to ensure the repo
maintains only necessary catalog data.