### PR TITLE
chore(de): require 3 minimum for npm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
 	],
 	"lockFileMaintenance": { "enabled": true, "automerge": true },
 	"packageRules": [
+		{ "matchDatasources": ["npm"], "minimumReleaseAge": "3 days" },
 		{ "matchPackageNames": ["/relay/"], "groupName": "relay" },
 		{
 			"matchPackageNames": ["mcr.microsoft.com/playwright", "@playwright/*"],


### PR DESCRIPTION
Add a package rule in renovate.json to enforce a minimum release
age of  days for npm datasource updates. This reduces noise from
immediate upstream releases and gives time for initial post-release
fixes before Renovate proposes automated updates.

Also preserve existing lockfile maintenance and playwright/relay
grouping rules.