### PR TITLE
chore(pnpm): bump package manager to 10.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	"devEngines": {
 		"packageManager": {
 			"name": "pnpm",
-			"version": "10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+			"version": "10.15.0"
 		},
 		"runtime": {
 			"name": "node",


### PR DESCRIPTION
Update devEngines.packageManager.version from a specific sha512
identifier to the explicit pnpm release 10.15.0. This simplifies the
engine declaration and ensures the project uses the published pnpm
version instead of a pinned hash, improving reproducibility and
readability of the configuration.