### PR TITLE
fix: update imports to client entry SSR/runtime

### DIFF
--- a/apps/web/app/components/Sheet.tsx
+++ b/apps/web/app/components/Sheet.tsx
@@ -1,11 +1,11 @@
 import * as Ariakit from "@ariakit/react"
 import {
-	AnimatePresence,
-	animate,
-	motion,
-	useMotionValue,
-	useTransform,
-} from "motion/react"
+    AnimatePresence,
+    animate,
+    motion,
+    useMotionValue,
+    useTransform,
+} from "motion/react-client"
 import type { ComponentProps, JSX, ReactNode } from "react"
 import { createContext, useContext } from "react"
 import type { VariantProps } from "tailwind-variants"

--- a/apps/web/app/components/Sheet.tsx
+++ b/apps/web/app/components/Sheet.tsx
@@ -1,10 +1,10 @@
 import * as Ariakit from "@ariakit/react"
 import {
-    AnimatePresence,
-    animate,
-    motion,
-    useMotionValue,
-    useTransform,
+	AnimatePresence,
+	animate,
+	motion,
+	useMotionValue,
+	useTransform,
 } from "motion/react-client"
 import type { ComponentProps, JSX, ReactNode } from "react"
 import { createContext, useContext } from "react"

--- a/apps/web/app/components/Tabs.tsx
+++ b/apps/web/app/components/Tabs.tsx
@@ -1,5 +1,5 @@
 import { useStoreState } from "@ariakit/react"
-import { motion } from "motion/react"
+import { motion } from "motion/react-client"
 
 import * as Ariakit from "@ariakit/react"
 import type { ReactNode } from "react"

--- a/apps/web/app/components/Tooltip.tsx
+++ b/apps/web/app/components/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as Ariakit from "@ariakit/react"
-import { AnimatePresence, motion } from "motion/react"
+import { AnimatePresence, motion } from "motion/react-client"
 import type { ComponentProps, PropsWithChildren, ReactNode } from "react"
 import { createContext, useContext } from "react"
 import MaterialSymbolsArrowDropDown from "~icons/material-symbols/arrow-drop-down"

--- a/apps/web/app/lib/loading-renderer.tsx
+++ b/apps/web/app/lib/loading-renderer.tsx
@@ -1,7 +1,7 @@
-import { animate, motion, useMotionValue } from "motion/react"
+import { animate, motion, useMotionValue } from "motion/react-client"
 
 import { interpolate, type Options } from "flubber"
-import { MotionValue, useTransform } from "motion/react"
+import { MotionValue, useTransform } from "motion/react-client"
 import { useEffect, useState } from "react"
 
 const cogwheel =

--- a/apps/web/app/routes/Media/route.tsx
+++ b/apps/web/app/routes/Media/route.tsx
@@ -1,9 +1,9 @@
 import {
-    type ClientLoaderFunctionArgs,
-    useLocation,
-    useOutlet,
-    useParams,
-    useRouteLoaderData,
+	type ClientLoaderFunctionArgs,
+	useLocation,
+	useOutlet,
+	useParams,
+	useRouteLoaderData,
 } from "react-router"
 
 import { AnimatePresence, motion } from "motion/react-client"
@@ -14,19 +14,19 @@ import ReactRelay from "react-relay"
 import { Card } from "~/components/Card"
 import { LayoutBody, LayoutPane as PaneFlexible } from "~/components/Layout"
 import {
-    Menu,
-    MenuDivider,
-    MenuItemLeadingIcon,
-    MenuItemTrailingIcon,
-    MenuItemTrailingText,
-    MenuList,
-    MenuListItem,
-    MenuTrigger,
+	Menu,
+	MenuDivider,
+	MenuItemLeadingIcon,
+	MenuItemTrailingIcon,
+	MenuItemTrailingText,
+	MenuList,
+	MenuListItem,
+	MenuTrigger,
 } from "~/components/Menu"
 import {
-    TooltipPlain,
-    TooltipPlainContainer,
-    TooltipPlainTrigger,
+	TooltipPlain,
+	TooltipPlainContainer,
+	TooltipPlainTrigger,
 } from "~/components/Tooltip"
 import { button, fab } from "~/lib/button"
 import type { clientLoader as rootLoader } from "~/root"

--- a/apps/web/app/routes/Media/route.tsx
+++ b/apps/web/app/routes/Media/route.tsx
@@ -1,12 +1,12 @@
 import {
-	type ClientLoaderFunctionArgs,
-	useLocation,
-	useOutlet,
-	useParams,
-	useRouteLoaderData,
+    type ClientLoaderFunctionArgs,
+    useLocation,
+    useOutlet,
+    useParams,
+    useRouteLoaderData,
 } from "react-router"
 
-import { AnimatePresence, motion } from "motion/react"
+import { AnimatePresence, motion } from "motion/react-client"
 
 import { useTooltipStore } from "@ariakit/react"
 import { cloneElement } from "react"
@@ -14,19 +14,19 @@ import ReactRelay from "react-relay"
 import { Card } from "~/components/Card"
 import { LayoutBody, LayoutPane as PaneFlexible } from "~/components/Layout"
 import {
-	Menu,
-	MenuDivider,
-	MenuItemLeadingIcon,
-	MenuItemTrailingIcon,
-	MenuItemTrailingText,
-	MenuList,
-	MenuListItem,
-	MenuTrigger,
+    Menu,
+    MenuDivider,
+    MenuItemLeadingIcon,
+    MenuItemTrailingIcon,
+    MenuItemTrailingText,
+    MenuList,
+    MenuListItem,
+    MenuTrigger,
 } from "~/components/Menu"
 import {
-	TooltipPlain,
-	TooltipPlainContainer,
-	TooltipPlainTrigger,
+    TooltipPlain,
+    TooltipPlainContainer,
+    TooltipPlainTrigger,
 } from "~/components/Tooltip"
 import { button, fab } from "~/lib/button"
 import type { clientLoader as rootLoader } from "~/root"

--- a/apps/web/app/routes/MediaEdit/route.tsx
+++ b/apps/web/app/routes/MediaEdit/route.tsx
@@ -19,7 +19,7 @@
 
 // import * as Ariakit from "@ariakit/react"
 
-// import { motion } from "motion/react"
+// import { motion } from "motion/react-client"
 // import type { ComponentProps } from "react"
 import type { ReactNode } from "react"
 // import { createDialog } from "~/lib/dialog"


### PR DESCRIPTION
motion imports from "motion/react"
"motion/react-client" across files to ensure the
runtime-compatible client entry is used. This changes imports
in routes, components, and lib modules (Tabs, Sheet, Tooltip,
loading-renderer, Media and MediaEdit routes) and also adjusts
some import formatting for consistency.

This prevents server-side/SSR import issues and aligns with the
motion library's client-only entrypoint, avoiding runtime errors
when rendering on the client.