### PR TITLE
chore(renovate): adjust lockfile and packageRules behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,16 +7,14 @@
 		":pinDependencies",
 		":automergeStableNonMajor"
 	],
-	"lockFileMaintenance": { "enabled": true, "automerge": true },
+	"lockFileMaintenance": { "enabled": true },
 	"packageRules": [
-		{ "matchDatasources": ["npm"], "minimumReleaseAge": "3 days" },
 		{ "matchPackageNames": ["/relay/"], "groupName": "relay" },
 		{
 			"matchPackageNames": ["mcr.microsoft.com/playwright", "@playwright/*"],
 			"groupName": "playwright"
 		},
 		{ "matchPackageNames": ["/oxlint/"], "groupName": "oxlint" },
-		{ "matchDepTypes": ["devDependencies", "action"], "automerge": true },
 		{
 			"matchDepTypes": ["action"],
 			"matchUpdateTypes": ["digest"],


### PR DESCRIPTION
Update renovate.json to disable lockfile automerge and tighten
packageRules to avoid unconditional automerge and remove the default
npm minimumReleaseAge.

- Disable automatic automerge for lockfile maintenance by removing
  "automerge": true so lockfile updates require review.
- Remove the global npm minimumReleaseAge rule, simplifying the ruleset.
- Remove a broad rule that automatically merged devDependencies and
  action updates; instead, keep a more specific rule set for actions
  and digest updates to control which updates are grouped and merged.

These changes reduce risky automatic merges and make Renovate's
behavior more explicit and reviewable.