### PR TITLE
chore(pkg): remove packageManager and engines fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,14 +44,7 @@
 		"wrangler": "catalog:"
 	},
 	"packageManager": "pnpm@10.15.0",
-	"engines": {
-		"node": ">=22.14.0"
-	},
 	"devEngines": {
-		"packageManager": {
-			"name": "pnpm",
-			"version": ">=10.15.0"
-		},
 		"runtime": {
 			"name": "node",
 			"version": ">=22.14.0"


### PR DESCRIPTION
Remove top-level "packageManager" and "engines.node" entries from package.json.
These fields were redundant with devEngines.packageManager and caused conflicts
with CI and contributor environments that rely on dev-only engine settings.
Rely on devEngines for tool-specific package manager configuration and avoid
enforcing a global Node version in package.json.