### PR TITLE
chore(ci): add manual dispatch to GitHub workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,7 @@ on:
       - renovate/**
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
       - renovate/**
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,7 @@ on:
       - renovate/**
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - renovate/**
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Enable workflow_dispatch on CI workflows (format, chromatic,
deploy, test) so maintainers can trigger these pipelines manually
from the repository UI. This provides a convenient way to run the
jobs on-demand for debugging, ad-hoc releases, or verification
without relying solely on automated triggers.