### PR TITLE
chore(deps): set minimumReleaseAge for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
 	],
 	"lockFileMaintenance": { "enabled": true },
 	"packageRules": [
-		{ "minimumReleaseAge": "1 days" },
+		{ "minimumReleaseAge": "1 day" },
 		{ "matchPackageNames": ["/relay/"], "groupName": "relay" },
 		{
 			"matchPackageNames": ["mcr.microsoft.com/playwright", "@playwright/*"],


### PR DESCRIPTION
Add a global minimumReleaseAge of 1 day to renovate.json so Renovatewaits at least one day before proposing upgrades. This reduces noise
from transient or very recent releases and gives downstream fixes time
to land before automated PRs are opened. Maintain existing package
rules for relay and Playwright grouping intact.