### PR TITLE
chore(ovate): move minimumReleaseAge to root config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,8 @@
 		":automergeStableNonMajor"
 	],
 	"lockFileMaintenance": { "enabled": true },
+	"minimumReleaseAge": "1 day",
 	"packageRules": [
-		{ "minimumReleaseAge": "1 day" },
 		{ "matchPackageNames": ["/relay/"], "groupName": "relay" },
 		{
 			"matchPackageNames": ["mcr.microsoft.com/playwright", "@playwright/*"],


### PR DESCRIPTION
Move the "minimumReleaseAge" setting from a package rule into the
root of renovate.json so it applies globally. Remove the redundant
per-package-rule entry and add "minimumReleaseAge": "1 day" at the
top. This ensures PRs respect a minimum release age by default
and simplifies packageRules.