### PR TITLE
fix(eslint-config): correct tsconfigRootDir path order

### DIFF
--- a/packages/eslint-config/src/eslint.config.ts
+++ b/packages/eslint-config/src/eslint.config.ts
@@ -69,7 +69,7 @@ export default await typegen([
 			parserOptions: {
 				projectService: true,
 				project: ["./apps/*/tsconfig.json", "./packages/*/tsconfig.json"],
-				tsconfigRootDir: path.join("..", "..", import.meta.dirname),
+				tsconfigRootDir: path.join(import.meta.dirname, "..", ".."),
 			},
 		},
 	},


### PR DESCRIPTION
Adjust tsconfigRootDir construction to use import.meta.dirname
first, then navigate up two directories. The previous order
reversed the path segments which produced incorrect root directory
resolution for TypeScript project references. This change ensures
parserOptions.project paths resolve correctly for workspace apps
and packages.