### PR TITLE
refactor: add rule name and use satisfies for typing

### DIFF
--- a/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
+++ b/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
@@ -8,7 +8,8 @@ import type {
 	RuleModule,
 } from "@typescript-eslint/utils/ts-eslint"
 
-export const rule: RuleModule<string> = {
+export const rule = {
+	name: 'rule-must-include-data-key',
 	meta: {
 		type: "suggestion",
 		docs: { description: "" },
@@ -81,7 +82,7 @@ export const rule: RuleModule<string> = {
 			},
 		}
 	},
-}
+} satisfies RuleModule<string>
 
 function isEqual(
 	context: RuleContext<string, []>,

--- a/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
+++ b/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
@@ -9,7 +9,7 @@ import type {
 } from "@typescript-eslint/utils/ts-eslint"
 
 export const rule = {
-	name: 'rule-must-include-data-key',
+	name: "rule-must-include-data-key",
 	meta: {
 		type: "suggestion",
 		docs: { description: "" },


### PR DESCRIPTION
Change the exported rule object to include an explicit name property
("rule-must-include-data-key") and replace the explicit RuleModule
annotation with a TypeScript "satisfies RuleModule<string>" check.

Thisifies the rule identity for consumers and the implementation
retain more precise narrowing while still ensuring it conforms to the
RuleModule shape. Also adjust formatting to keep typings strict without
over-annotating the exported symbol.