### PR TITLE
fix(search): remove unnecessary listener dependency

### DIFF
--- a/apps/web/app/lib/search/Search.tsx
+++ b/apps/web/app/lib/search/Search.tsx
@@ -79,7 +79,7 @@ export function Search({
 		return () => {
 			window.removeEventListener("keydown", listener)
 		}
-	}, [listener])
+	}, [])
 
 	const media = submit.data?.page?.media?.filter((el) => el != null) ?? []
 


### PR DESCRIPTION
Remove the listener function from the useEffect dependency array to
prevent re-registering the keydown event handler on every render.
This ensures the event listener is added once on mount and removed on
unmount, avoiding potential duplicate handlers and unexpected behavior.