### PR TITLE
chore(runtime): bump Node runtime requirement to 22.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"devEngines": {
 		"runtime": {
 			"name": "node",
-			"version": "^22.14.0",
+			"version": "^22.18.0",
 			"onFail": "download"
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
         specifier: 'catalog:'
         version: 5.64.1(@types/node@22.18.8)(typescript@5.9.3)
       node:
-        specifier: runtime:^22.14.0
+        specifier: runtime:^22.18.0
         version: runtime:22.20.0
       oxlint:
         specifier: 'catalog:'


### PR DESCRIPTION
Update lockfile and package devEngines to require Node ^22.18.0
instead of ^22.14.0. This aligns the declared engine with the
installed/runtime version in pnpm-lock.yaml (runtime:22.20.0)
and ensures local development and CI use a consistent, newer Node
release to avoid discrepancies and leverage bug fixes/security
updates.