### PR TITLE
fix(layout): simplify grid column selectors for list items

### DIFF
--- a/apps/web/app/components/List.tsx
+++ b/apps/web/app/components/List.tsx
@@ -83,10 +83,8 @@ const listItemContentDefinition = defineCva({
 		flexDirection: "column",
 		gridColumn: {
 			"&:first-child": "span 2 / span 2",
-			"&:last-child": {
-				base: "span 2 / span 2",
-				"&:first-child": "span 3 / span 3",
-			},
+			"&:last-child": "span 2 / span 2",
+			"&:only-child": "span 3 / span 3",
 		},
 	},
 	variants: {


### PR DESCRIPTION
## Summary by Sourcery

Simplify list item grid column selectors to more accurately handle single-child and edge layout cases.

Bug Fixes:
- Correct grid column behavior for lists with a single item by using an :only-child selector instead of combining :first-child with :last-child.

Enhancements:
- Simplify grid column selector logic for list items by replacing nested :last-child and :first-child rules with a dedicated :only-child rule.