### PR TITLE
refactorlint): remove typescript preset usage

### DIFF
--- a/apps/storybook/env.ts
+++ b/apps/storybook/env.ts
@@ -1,7 +1,6 @@
 /// <reference types="vite/client" />
 
 declare module "react" {
-	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 	interface CSSProperties {
 		[key: `--${string}`]: number | string
 	}

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -12,7 +12,6 @@ interface ButtonProps extends ComponentProps<"button"> {
 }
 
 declare module "react" {
-	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 	interface CSSProperties {
 		[key: `--${string}`]: number | string | undefined
 	}

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -2,7 +2,6 @@
 /// <reference types="vite/client" />
 
 declare module "react" {
-	// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 	interface CSSProperties {
 		[key: `--${string}`]: number | string
 	}

--- a/packages/eslint-config/src/eslint.config.ts
+++ b/packages/eslint-config/src/eslint.config.ts
@@ -7,7 +7,7 @@ import turbo from "eslint-plugin-turbo"
 import typegen from "eslint-typegen"
 import oxlintConfig from "oxlint-config" with { type: "json" }
 import path from "path"
-
+import tseslint from "typescript-eslint"
 export default await typegen([
 	{
 		name: "eslint-config/ignores",
@@ -36,6 +36,7 @@ export default await typegen([
 			"perfectionist/sort-objects": "off",
 		},
 	},
+	...tseslint.configs.recommended,
 	{
 		name: "eslint-config/typescript-eslint/parser-options",
 		languageOptions: {
@@ -45,27 +46,6 @@ export default await typegen([
 			},
 		},
 	},
-	// {
-	// files: ["**/*.{ts,tsx}"],
-	// rules: {
-	// ...import_.configs.recommended.rules,
-	// ...import_.configs.typescript.rules,
-	// "@typescript-eslint/no-unnecessary-condition": "error",
-	// "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
-	// "@typescript-eslint/dot-notation": "error",
-	// "@typescript-eslint/restrict-plus-operands": "warn",
-	// "@typescript-eslint/no-floating-promises": "error",
-	// "@typescript-eslint/promise-function-async": "error",
-	// "@typescript-eslint/no-misused-promises": "error",
-	// "@typescript-eslint/return-await": "error",
-	// "@typescript-eslint/no-unused-vars": ["warn"],
-	// "@typescript-eslint/explicit-module-boundary-types": "warn",
-	// "@typescript-eslint/method-signature-style": ["error", "property"],
-	// "@typescript-eslint/no-explicit-any": "off",
-	// 	},
-	// },
-
-	// turbo.configs["flat/recommended"],
 
 	{
 		rules: {

--- a/packages/eslint-config/src/eslint.config.ts
+++ b/packages/eslint-config/src/eslint.config.ts
@@ -7,7 +7,6 @@ import turbo from "eslint-plugin-turbo"
 import typegen from "eslint-typegen"
 import oxlintConfig from "oxlint-config" with { type: "json" }
 import path from "path"
-import tseslint from "typescript-eslint"
 
 export default await typegen([
 	{
@@ -37,33 +36,6 @@ export default await typegen([
 			"perfectionist/sort-objects": "off",
 		},
 	},
-	...[
-		...tseslint.configs.strictTypeChecked,
-		...tseslint.configs.stylisticTypeChecked,
-	].map((config) => ({
-		files: [
-			"**/*.js",
-			"**/*.cjs",
-			"**/*.mjs",
-			"**/*.jsx",
-			"**/*.cjsx",
-			"**/*.mjsx",
-			"**/*.ts",
-			"**/*.cts",
-			"**/*.mts",
-			"**/*.tsx",
-			"**/*.ctsx",
-			"**/*.mtsx",
-		],
-		...config,
-		rules: {
-			...config.rules,
-			"@typescript-eslint/triple-slash-reference": "off",
-			"@typescript-eslint/only-throw-error": "off",
-			"@typescript-eslint/no-floating-promises": "error",
-			"@typescript-eslint/no-empty-object-type": "off",
-		},
-	})),
 	{
 		name: "eslint-config/typescript-eslint/parser-options",
 		languageOptions: {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplify the ESLint configuration by inlining only the necessary TypeScript rule overrides without extending the strict/stylistic TypeScript presets.