### PR TITLE
fix(rate): add dual rate limiters and compose for fetch

### DIFF
--- a/apps/web/app/lib/Network/RateLimiter.test.tsx
+++ b/apps/web/app/lib/Network/RateLimiter.test.tsx
@@ -13,10 +13,9 @@ void describe("RateLimiter", () => {
 
 	void describe("Basic functionality", () => {
 		it("should execute functions immediately when within rate limit", async () => {
-			const limiter = new RateLimiter({
-				limit: 3,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 1),
-			})
+			const limiter = new RateLimiter([
+				{ limit: 3, per: new Temporal.Duration(0, 0, 0, 0, 0, 1) },
+			])
 
 			const results: number[] = []
 			const promises = [
@@ -30,10 +29,9 @@ void describe("RateLimiter", () => {
 		})
 
 		it("should delay execution when rate limit is exceeded", async () => {
-			const limiter = new RateLimiter({
-				limit: 2,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 1),
-			})
+			const limiter = new RateLimiter([
+				{ limit: 2, per: new Temporal.Duration(0, 0, 0, 0, 0, 1) },
+			])
 
 			const results: number[] = []
 			const startTime = Date.now()
@@ -55,10 +53,9 @@ void describe("RateLimiter", () => {
 		})
 
 		it("should handle multiple batches correctly", async () => {
-			const limiter = new RateLimiter({
-				limit: 2,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 1),
-			})
+			const limiter = new RateLimiter([
+				{ limit: 2, per: new Temporal.Duration(0, 0, 0, 0, 0, 1) },
+			])
 
 			const results: number[] = []
 			const timings: number[] = []
@@ -89,10 +86,9 @@ void describe("RateLimiter", () => {
 
 	void describe("Error handling", () => {
 		it("should propagate errors from executed functions", async () => {
-			const limiter = new RateLimiter({
-				limit: 1,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 1),
-			})
+			const limiter = new RateLimiter([
+				{ limit: 1, per: new Temporal.Duration(0, 0, 0, 0, 0, 1) },
+			])
 
 			const error = new Error("Test error")
 			const promise = limiter.execute(() => {
@@ -103,10 +99,9 @@ void describe("RateLimiter", () => {
 		})
 
 		it("should continue processing queue after an error", async () => {
-			const limiter = new RateLimiter({
-				limit: 2,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 1),
-			})
+			const limiter = new RateLimiter([
+				{ limit: 2, per: new Temporal.Duration(0, 0, 0, 0, 0, 1) },
+			])
 
 			const results: number[] = []
 			const promises = [
@@ -132,10 +127,9 @@ void describe("RateLimiter", () => {
 
 	void describe("Concurrency", () => {
 		it("should handle concurrent execute calls", async () => {
-			const limiter = new RateLimiter({
-				limit: 1,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 1),
-			})
+			const limiter = new RateLimiter([
+				{ limit: 1, per: new Temporal.Duration(0, 0, 0, 0, 0, 1) },
+			])
 
 			const results: number[] = []
 			const promises = [
@@ -157,10 +151,9 @@ void describe("RateLimiter", () => {
 
 	void describe("Edge cases", () => {
 		it("should handle limit of 1", async () => {
-			const limiter = new RateLimiter({
-				limit: 1,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 0, 500), // 500ms
-			})
+			const limiter = new RateLimiter([
+				{ limit: 1, per: Temporal.Duration.from({ milliseconds: 500 }) },
+			])
 
 			const results: number[] = []
 			const timings: number[] = []
@@ -186,10 +179,9 @@ void describe("RateLimiter", () => {
 		})
 
 		it("should handle large number of queued items", async () => {
-			const limiter = new RateLimiter({
-				limit: 5,
-				per: new Temporal.Duration(0, 0, 0, 0, 0, 1),
-			})
+			const limiter = new RateLimiter([
+				{ limit: 5, per: new Temporal.Duration(0, 0, 0, 0, 0, 1) },
+			])
 
 			const results: number[] = []
 			const promises = Array.from({ length: 20 }, (_, i) =>

--- a/apps/web/app/lib/Network/RateLimiter.tsx
+++ b/apps/web/app/lib/Network/RateLimiter.tsx
@@ -74,7 +74,7 @@ export class RateLimiter {
 
 			// Record timestamp for all limits
 			for (const { timestamps } of this.timestamps) {
-				timestamps.push(now)
+				void timestamps.push(now)
 			}
 			void fn()
 		}

--- a/apps/web/app/lib/Network/RateLimiter.tsx
+++ b/apps/web/app/lib/Network/RateLimiter.tsx
@@ -1,10 +1,17 @@
+type RateLimiterArgs = { limit: number; per: Temporal.Duration }
+
 export class RateLimiter {
 	private processing = false
-	private queue = new Array<() => Promise<void>>()
+	private queue: (() => Promise<void>)[] = []
 
-	private timestamps = new Array<Temporal.Instant>()
+	private timestamps: {
+		timestamps: Temporal.Instant[]
+		args: RateLimiterArgs
+	}[]
 
-	constructor(private args: { limit: number; per: Temporal.Duration }) {}
+	constructor(args: readonly RateLimiterArgs[]) {
+		this.timestamps = args.map((args) => ({ args, timestamps: [] }))
+	}
 
 	execute<T>(fn: () => T): Promise<Awaited<T>> {
 		return new Promise<Awaited<T>>((resolve, reject) => {
@@ -32,22 +39,31 @@ export class RateLimiter {
 		while (this.queue.length !== 0) {
 			const now = Temporal.Now.instant()
 
-			// Remove timestamps older than window
-			this.timestamps = this.timestamps.filter(
-				(t) => t.add(this.args.per).epochMilliseconds > now.epochMilliseconds
-			)
-
-			if (this.timestamps.length >= this.args.limit) {
-				const earliest = this.timestamps[0]
-				if (!earliest) {
-					throw new Error(
-						"RateLimiter timestamps is empty when trying to process"
-					)
+			// Clean timestamps for each limit
+			this.timestamps = this.timestamps.map(({ args, timestamps }) => {
+				return {
+					args,
+					timestamps: timestamps.filter(
+						(t) => t.add(args.per).epochMilliseconds > now.epochMilliseconds
+					),
 				}
-				const nextAllowed = earliest.add(this.args.per)
+			})
 
-				const waitMs = nextAllowed.epochMilliseconds - now.epochMilliseconds
-				await new Promise((r) => setTimeout(r, waitMs))
+			// Check if any limit is exceeded and calculate max wait time
+			let maxWait = 0
+			for (const { timestamps, args } of this.timestamps) {
+				if (timestamps.length >= args.limit) {
+					const earliest = timestamps[0]
+					if (earliest) {
+						const nextAllowed = earliest.add(args.per)
+						const waitMs = nextAllowed.epochMilliseconds - now.epochMilliseconds
+						if (waitMs > maxWait) maxWait = waitMs
+					}
+				}
+			}
+
+			if (maxWait > 0) {
+				await new Promise((r) => setTimeout(r, maxWait))
 				continue
 			}
 
@@ -55,7 +71,11 @@ export class RateLimiter {
 			if (!fn) {
 				throw new Error("RateLimiter queue is empty when trying to process")
 			}
-			void this.timestamps.push(Temporal.Now.instant())
+
+			// Record timestamp for all limits
+			for (const { timestamps } of this.timestamps) {
+				timestamps.push(now)
+			}
 			void fn()
 		}
 

--- a/apps/web/app/lib/Network/RateLimiter.tsx
+++ b/apps/web/app/lib/Network/RateLimiter.tsx
@@ -5,8 +5,8 @@ export class RateLimiter {
 	private queue: (() => Promise<void>)[] = []
 
 	private timestamps: {
-		timestamps: Temporal.Instant[]
 		args: RateLimiterArgs
+		timestamps: Temporal.Instant[]
 	}[]
 
 	constructor(args: readonly RateLimiterArgs[]) {

--- a/apps/web/app/lib/Network/environment.tsx
+++ b/apps/web/app/lib/Network/environment.tsx
@@ -75,11 +75,22 @@ const fetchQuery = async function (
 const rateLimiter =
 	typeof document === "undefined"
 		? undefined
-		: new RateLimiter({ limit: 4, per: Temporal.Duration.from({ seconds: 1 }) })
+		: {
+				_30Per1Minute: new RateLimiter({
+					limit: 30,
+					per: Temporal.Duration.from({ minutes: 1 }),
+				}),
+				_4Per1Second: new RateLimiter({
+					limit: 4,
+					per: Temporal.Duration.from({ seconds: 1 }),
+				}),
+			}
 
 const rateLimitedFetch = rateLimiter
 	? (input: string | URL, init?: RequestInit): Promise<Response> =>
-			rateLimiter.execute(() => fetch(input, init))
+			rateLimiter._4Per1Second.execute(() =>
+				rateLimiter._30Per1Minute.execute(() => fetch(input, init))
+			)
 	: fetch
 
 // Create a network layer from the fetch function

--- a/apps/web/app/lib/Network/environment.tsx
+++ b/apps/web/app/lib/Network/environment.tsx
@@ -75,22 +75,14 @@ const fetchQuery = async function (
 const rateLimiter =
 	typeof document === "undefined"
 		? undefined
-		: {
-				_30Per1Minute: new RateLimiter({
-					limit: 30,
-					per: Temporal.Duration.from({ minutes: 1 }),
-				}),
-				_4Per1Second: new RateLimiter({
-					limit: 4,
-					per: Temporal.Duration.from({ seconds: 1 }),
-				}),
-			}
+		: new RateLimiter([
+				{ limit: 30, per: Temporal.Duration.from({ minutes: 1 }) },
+				{ limit: 4, per: Temporal.Duration.from({ seconds: 1 }) },
+			])
 
 const rateLimitedFetch = rateLimiter
 	? (input: string | URL, init?: RequestInit): Promise<Response> =>
-			rateLimiter._4Per1Second.execute(() =>
-				rateLimiter._30Per1Minute.execute(() => fetch(input, init))
-			)
+			rateLimiter.execute(() => fetch(input, init))
 	: fetch
 
 // Create a network layer from the fetch function


### PR DESCRIPTION
## Summary by Sourcery

Support multiple concurrent rate-limiting windows and apply them to client-side fetch requests.

New Features:
- Allow configuring the RateLimiter with multiple limit/window configurations that are enforced together on each execution.

Enhancements:
- Refactor RateLimiter to track timestamps per configured limit window and compute the appropriate delay when any limit would be exceeded.
- Increase robustness of client-side network layer by composing both short-term and longer-term rate limits for fetch requests.

Tests:
- Update RateLimiter tests to construct the limiter with an array of rate limit configurations, matching the new API.