### PR TITLE
chore(config): migrate .npmrc keys into pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,0 @@
-save-prefix=''
-shell-emulator=true
-enable-pre-post-scripts=false
-resolution-mode=lowest-direct
-verify-deps-before-run=install
-catalog-mode=strict
-cleanup-unused-catalogs=true
-optimistic-repeat-install=true

--- a/apps/web/app/lib/Network/RateLimiter.tsx
+++ b/apps/web/app/lib/Network/RateLimiter.tsx
@@ -1,4 +1,7 @@
-type RateLimiterArgs = { limit: number; per: Temporal.Duration }
+interface RateLimiterArgs {
+	limit: number
+	per: Temporal.Duration
+}
 
 export class RateLimiter {
 	private processing = false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,19 +114,18 @@ catalog:
   vite-plugin-relay: 2.1.0
   vitest: 4.1.4
   wrangler: 4.81.0
-trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: 4320
+catalogMode: strict
+cleanupUnusedCatalogs: true
 dedupePeers: true
+enablePrePostScripts: false
 nodeLinker: hoisted
+optimisticRepeatInstall: true
 
 patchedDependencies:
   flubber: patches/flubber.patch
 
 savePrefix: ''
 shellEmulator: true
-enablePrePostScripts: false
-resolutionMode: lowestDirect
-catalogMode: strict
-cleanupUnusedCatalogs: true
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 4320
 verifyDepsBeforeRun: install
-optimisticRepeatInstall: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,18 +114,18 @@ catalog:
   vite-plugin-relay: 2.1.0
   vitest: 4.1.4
   wrangler: 4.81.0
-catalogMode: strict
-cleanupUnusedCatalogs: true
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 4320
 dedupePeers: true
-enablePrePostScripts: false
 nodeLinker: hoisted
-optimisticRepeatInstall: true
 
 patchedDependencies:
   flubber: patches/flubber.patch
 
 savePrefix: ''
 shellEmulator: true
-trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: 4320
+enablePrePostScripts: false
+catalogMode: strict
+cleanupUnusedCatalogs: true
 verifyDepsBeforeRun: install
+optimisticRepeatInstall: true


### PR DESCRIPTION
## Summary by Sourcery

Migrate npm configuration into pnpm-workspace settings and perform a minor type refactor.

Enhancements:
- Consolidate former .npmrc settings into pnpm-workspace.yaml, updating catalog and trust-related options.
- Refine the RateLimiter configuration type by switching RateLimiterArgs from a type alias to an interface.