### PR TITLE
chore: patch for material color utilities dependency

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,8 +114,8 @@ catalog:
   vite-plugin-relay: 2.1.0
   vitest: 4.1.4
   wrangler: 4.81.0
-trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: 4320
+# trustPolicy: no-downgrade
+# trustPolicyIgnoreAfter: 4320
 dedupePeers: true
 nodeLinker: hoisted
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Comment out pnpm trust policy and trustPolicyIgnoreAfter settings in the workspace configuration.