### PR TITLE
chore): add prefer-template ESLint rule to config

### DIFF
--- a/packages/oxlint-config/oxlintrc.json
+++ b/packages/oxlint-config/oxlintrc.json
@@ -15,6 +15,7 @@
 	"rules": {
 		"eslint/no-unused-expressions ": "error",
 		"eslint/eqeqeq ": "error",
+		"eslint/prefer-template ": "error",
 		"oxc/no-barrel-file": "error",
 		"import/no-cycle": "error",
 		"react/jsx-no-useless-fragment": "error",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Extend the oxlint ESLint config to enable the prefer-template rule for consistent string formatting across the codebase.