### PR TITLE
feat(media): add responsive src and sizes to MediaCover image

### DIFF
--- a/apps/web/app/lib/entry/MediaCover.tsx
+++ b/apps/web/app/lib/entry/MediaCover.tsx
@@ -45,6 +45,15 @@ export function MediaCover({ media, ...props }: MediaCoverProps): ReactNode {
 				?? ""
 			}
 			loading="lazy"
+			sizes="auto"
+			srcSet={[
+				[100, data.coverImage?.medium],
+				[230, data.coverImage?.large],
+				[460, data.coverImage?.extraLarge],
+			]
+				.map(([width, url]) => (url ? `${url} ${width}w` : null))
+				.filter(Boolean)
+				.join(", ")}
 			alt=""
 			{...props}
 			style={{

--- a/apps/web/app/lib/entry/MediaCover.tsx
+++ b/apps/web/app/lib/entry/MediaCover.tsx
@@ -13,6 +13,7 @@ const cover = tv({
 })
 
 import * as Ariakit from "@ariakit/react"
+import { numberToString } from "../numberToString"
 
 interface MediaCoverProps extends Ariakit.RoleProps<"img"> {
 	media: MediaCover_media$key
@@ -46,12 +47,16 @@ export function MediaCover({ media, ...props }: MediaCoverProps): ReactNode {
 			}
 			loading="lazy"
 			sizes="auto"
-			srcSet={[
-				[100, data.coverImage?.medium],
-				[230, data.coverImage?.large],
-				[460, data.coverImage?.extraLarge],
-			]
-				.map(([width, url]) => (url ? `${url} ${width}w` : null))
+			srcSet={(
+				[
+					[100, data.coverImage?.medium],
+					[230, data.coverImage?.large],
+					[460, data.coverImage?.extraLarge],
+				] as const
+			)
+				.map(([width, url]) =>
+					url ? `${url} ${numberToString(width)}w` : null
+				)
 				.filter(Boolean)
 				.join(", ")}
 			alt=""


### PR DESCRIPTION
## Summary by Sourcery

Add responsive source attributes to the media cover image component to improve image loading across different resolutions.

New Features:
- Provide a srcSet with multiple resolutions for the MediaCover image based on available cover image sizes.
- Specify the sizes attribute on the MediaCover image to enable responsive image selection by the browser.