### PR TITLE
chore: updatepm lock to replace prettier oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,21 @@
+{
+	"semi": false,
+	"sortTailwindcss": { "functions": ["tv"] },
+	"useTabs": true,
+	"trailingComma": "es5",
+	"objectWrap": "collapse",
+	"printWidth": 80,
+	"sortPackageJson": false,
+	"ignorePatterns": [
+		"**/gql",
+		"pnpm-lock.yaml",
+		"pnpm-workspace.yaml",
+		"worker-configuration.d.ts",
+		"eslint-typegen.d.ts",
+		"**/.react-router",
+		"**/.tsup",
+		"**/dist",
+		"eslint-suppressions.json"
+	],
+	"jsdoc": true
+}

--- a/apps/web/app/components/AppBar.tsx
+++ b/apps/web/app/components/AppBar.tsx
@@ -19,16 +19,16 @@ const appBar = tv(
 			},
 			hide: {
 				true: {
-					root: "data-[hidden='true']:-translate-y-(--app-bar-height) transform-gpu transition-transform ease-spatial duration-spatial sm:data-[hidden='true']:translate-y-0",
+					root: "ease-spatial duration-spatial transform-gpu transition-transform data-[hidden='true']:-translate-y-(--app-bar-height) sm:data-[hidden='true']:translate-y-0",
 				},
 				false: { root: "" },
 			},
 			variant: {
 				centered: { root: "" },
-				small: { root: "h-16 px-2 pb-3 pt-3" },
+				small: { root: "h-16 px-2 pt-3 pb-3" },
 				medium: { root: "" },
 				large: {
-					root: "animate-app-bar-large h-28 px-2 pb-6 pt-3 [animation-range:0_7rem] [animation-timeline:scroll()]",
+					root: "animate-app-bar-large h-28 px-2 pt-3 pb-6 [animation-range:0_7rem] [animation-timeline:scroll()]",
 				},
 			},
 		},

--- a/apps/web/app/components/Checkbox.tsx
+++ b/apps/web/app/components/Checkbox.tsx
@@ -18,13 +18,13 @@ export function Checkbox(props: Omit<Ariakit.CheckboxProps, "id">): ReactNode {
 			<Ariakit.VisuallyHidden>
 				<Ariakit.Checkbox {...props} id={id} />
 			</Ariakit.VisuallyHidden>
-			<div className="text-primary i group-has-checked:block hidden">
+			<div className="text-primary i hidden group-has-checked:block">
 				<MaterialSymbolsCheckBox />
 			</div>
 			<div className="i hidden group-has-[input:not(:checked)]:block">
 				<MaterialSymbolsCheckBoxOutlineBlank />
 			</div>
-			<div className="i group-has-indeterminate:block hidden">
+			<div className="i hidden group-has-indeterminate:block">
 				<MaterialSymbolsIndeterminateCheckBox />
 			</div>
 			<TouchTarget />
@@ -39,7 +39,7 @@ export function Radio(props: Omit<Ariakit.RadioProps, "id">): ReactNode {
 			<Ariakit.VisuallyHidden>
 				<Ariakit.Radio {...props} id={id} />
 			</Ariakit.VisuallyHidden>
-			<div className="text-primary i group-has-checked:block hidden">
+			<div className="text-primary i hidden group-has-checked:block">
 				<MaterialSymbolsRadioButtonCheckedOutline />
 			</div>
 			<div className="i hidden group-has-[input:not(:checked)]:block">

--- a/apps/web/app/components/Chip.tsx
+++ b/apps/web/app/components/Chip.tsx
@@ -26,7 +26,7 @@ export function ChipFilter(
 			<Label
 				{...props}
 				data-focus-visible={focusVisible || undefined}
-				className="border-outline text-label-lg text-on-surface-variant duration-spatial-fast ease-spatial-fast has-checked:bg-secondary-container has-checked:text-on-secondary-container hover:[&:not(\\\\#)]:state-hover has-focused:[&:not(\\\\#)]:state-focus has-checked:border-0 has-checked:shadow-sm flex h-8 items-center gap-2 rounded-sm border px-4 shadow-sm"
+				className="border-outline text-label-lg text-on-surface-variant duration-spatial-fast ease-spatial-fast has-checked:bg-secondary-container has-checked:text-on-secondary-container hover:[&:not(\\\\#)]:state-hover has-focused:[&:not(\\\\#)]:state-focus flex h-8 items-center gap-2 rounded-sm border px-4 shadow-sm has-checked:border-0 has-checked:shadow-sm"
 			/>
 		</FocusContext>
 	)
@@ -84,7 +84,7 @@ export function ChipFilterRadio(
 
 function ChipFilterIcon(): ReactNode {
 	return (
-		<div className="ease-spatial-fast duration-spatial-fast i-[1.125rem] peer-has-checked:w-[1.125rem] peer-has-checked:opacity-100 -ms-2 w-0 opacity-0 transition-all">
+		<div className="ease-spatial-fast duration-spatial-fast i-[1.125rem] -ms-2 w-0 opacity-0 transition-all peer-has-checked:w-[1.125rem] peer-has-checked:opacity-100">
 			<MaterialSymbolsCheck />
 		</div>
 	)

--- a/apps/web/app/components/Menu.tsx
+++ b/apps/web/app/components/Menu.tsx
@@ -42,7 +42,7 @@ const createMenu = tv({
 		button: "",
 		listItem:
 			"elevation-2 bg-surface-container text-label-lg text-on-surface hover:state-hover focus:state-focus group inset-[unset] flex h-12 items-center gap-3 px-3",
-		list: "bg-surface-container text-label-lg text-on-surface ease-spatial-fast duration-spatial-fast popover-open:transform-none popover-open:opacity-100 popover-open:starting:-translate-y-4 popover-open:starting:opacity-0 max-h-(--popover-available-height) rounded-xs transition-discrete top-[anchor(bottom)] z-50 flex min-w-[7rem] max-w-[17.5rem] translate-y-0 flex-col overflow-visible overscroll-contain py-2 opacity-0 motion-safe:transition-all",
+		list: "bg-surface-container text-label-lg text-on-surface ease-spatial-fast duration-spatial-fast popover-open:transform-none popover-open:opacity-100 popover-open:starting:-translate-y-4 popover-open:starting:opacity-0 top-[anchor(bottom)] z-50 flex max-h-(--popover-available-height) max-w-[17.5rem] min-w-[7rem] translate-y-0 flex-col overflow-visible overscroll-contain rounded-xs py-2 opacity-0 transition-discrete motion-safe:transition-all",
 	},
 })
 

--- a/apps/web/app/components/Sheet.tsx
+++ b/apps/web/app/components/Sheet.tsx
@@ -15,7 +15,7 @@ import { tv } from "~/lib/tailwind-variants"
 
 const sheet = tv({
 	slots: {
-		root: "bg-surface-container-low fixed bottom-0 left-0 top-[4.5rem] mx-auto my-0 mt-auto flex h-fit max-h-[calc(100%-4.5rem)] w-full max-w-[40rem] flex-col overflow-hidden rounded-t-xl min-[640px]:left-14 min-[640px]:right-14 min-[640px]:top-14 min-[640px]:max-h-[calc(100%-3.5rem)] min-[640px]:w-[calc(100%-7rem)]",
+		root: "bg-surface-container-low fixed top-[4.5rem] bottom-0 left-0 mx-auto my-0 mt-auto flex h-fit max-h-[calc(100%-4.5rem)] w-full max-w-[40rem] flex-col overflow-hidden rounded-t-xl min-[640px]:top-14 min-[640px]:right-14 min-[640px]:left-14 min-[640px]:max-h-[calc(100%-3.5rem)] min-[640px]:w-[calc(100%-7rem)]",
 		backdrop: "bg-scrim/(--opacity)",
 		container:
 			"text-body-md text-on-surface flex w-full flex-col overflow-auto overscroll-contain",
@@ -89,7 +89,7 @@ export function Sheet({ modal, variant, ...props }: SheetProps): JSX.Element {
 function SheetHandle(props: ComponentProps<"div">): ReactNode {
 	return (
 		<div
-			className="bg-on-surface-variant/[.4] rounded-xs mx-auto my-[1.375rem] h-1 w-8"
+			className="bg-on-surface-variant/[.4] mx-auto my-[1.375rem] h-1 w-8 rounded-xs"
 			{...props}
 		/>
 	)

--- a/apps/web/app/components/Skeleton.tsx
+++ b/apps/web/app/components/Skeleton.tsx
@@ -7,7 +7,7 @@ import * as Ariakit from "@ariakit/react"
 import { tv } from "~/lib/tailwind-variants"
 
 const skeleton = tv({
-	base: "bg-surface-container-highest rounded-xs animate-pulse select-none overflow-hidden text-transparent",
+	base: "bg-surface-container-highest animate-pulse overflow-hidden rounded-xs text-transparent select-none",
 	variants: {
 		full: {
 			true: "block h-full w-full",

--- a/apps/web/app/components/Snackbar.tsx
+++ b/apps/web/app/components/Snackbar.tsx
@@ -172,7 +172,7 @@ function Snackbar({ timeout, open, ...props }: SnackbarProps): ReactNode {
 				popover="manual"
 				data-timeout={timeout}
 				ref={ref}
-				className="bg-inverse-surface text-body-md text-inverse-on-surface rounded-xs mb-7 line-clamp-2 hidden min-h-[3rem] max-w-[calc(100%-2rem)] flex-wrap items-center gap-3 p-4 shadow-sm [&:popover-open]:flex"
+				className="bg-inverse-surface text-body-md text-inverse-on-surface mb-7 line-clamp-2 hidden min-h-[3rem] max-w-[calc(100%-2rem)] flex-wrap items-center gap-3 rounded-xs p-4 shadow-sm [&:popover-open]:flex"
 			/>
 		</SnackbarContext.Provider>
 	)

--- a/apps/web/app/components/Tabs.tsx
+++ b/apps/web/app/components/Tabs.tsx
@@ -16,7 +16,7 @@ const tabs = tv({
 	variants: {
 		variant: { primary: {}, secondary: {} },
 		grow: {
-			true: { root: "grid grid-flow-col [grid-auto-columns:minmax(0,1fr)]" },
+			true: { root: "grid [grid-auto-columns:minmax(0,1fr)] grid-flow-col" },
 			false: { root: "flex overflow-x-auto" },
 		},
 	},
@@ -71,7 +71,7 @@ export function TabsListItem({
 				{selectedId === props.id && (
 					<motion.div
 						layoutId={layoutId}
-						className="bg-primary absolute bottom-0 left-0 right-0 h-[0.1875rem] rounded-t-[0.1875rem]"
+						className="bg-primary absolute right-0 bottom-0 left-0 h-[0.1875rem] rounded-t-[0.1875rem]"
 					/>
 				)}
 			</div>

--- a/apps/web/app/components/TextField.tsx
+++ b/apps/web/app/components/TextField.tsx
@@ -40,18 +40,18 @@ function OutlinedLabel({ children, ...props }: ComponentProps<"label">) {
 		<>
 			<Label
 				{...props}
-				className="text-body-sm text-on-surface-variant group-focus-within:text-primary group-hover:text-on-surface group-hover:group-focus-within:text-primary peer-placeholder-shown:text-body-lg peer-placeholder-shown:group-focus-within:text-body-sm peer-disabled:text-on-surface/[.38] peer-disabled:group-hover:text-on-surface/[.38] group-error:text-error group-focus-within:group-error:text-error group-error:group-focus-within:text-error group-error:group-hover:text-on-error-container group-focus-within:group-error:group-hover:text-error peer-disabled:group-error:text-on-surface/[.38] group-error:peer-disabled:text-on-surface/[.38] group-has-required:after:content-['*'] pointer-events-none absolute -top-2 left-4 transition-all ease-spatial-fast duration-spatial-fast peer-placeholder-shown:top-4 peer-placeholder-shown:group-focus-within:-top-2 peer-placeholder-shown:group-focus-within:left-4"
+				className="text-body-sm text-on-surface-variant group-focus-within:text-primary group-hover:text-on-surface group-hover:group-focus-within:text-primary peer-placeholder-shown:text-body-lg peer-placeholder-shown:group-focus-within:text-body-sm peer-disabled:text-on-surface/[.38] peer-disabled:group-hover:text-on-surface/[.38] group-error:text-error group-focus-within:group-error:text-error group-error:group-focus-within:text-error group-error:group-hover:text-on-error-container group-focus-within:group-error:group-hover:text-error peer-disabled:group-error:text-on-surface/[.38] group-error:peer-disabled:text-on-surface/[.38] ease-spatial-fast duration-spatial-fast pointer-events-none absolute -top-2 left-4 transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:group-focus-within:-top-2 peer-placeholder-shown:group-focus-within:left-4 group-has-required:after:content-['*']"
 			>
 				{children}
 			</Label>
 
-			<fieldset className="border-outline group-focus-within:border-primary group-hover:border-on-surface group-focus-within:group-hover:border-primary group-has-disabled:border-outline/[.12] group-has-disabled:group-hover:border-outline/[.12] group-error:border-error group-error:group-focus-within:border-error group-error:group-hover:border-on-error-container group-error:group-hover:group-focus-within:border-error rounded-xs pointer-events-none absolute -top-[0.71875rem] bottom-0 left-0 right-0 border px-[0.625rem] transition-all group-focus-within:border-2 ease-effects-fast duration-effects-fast">
+			<fieldset className="border-outline group-focus-within:border-primary group-hover:border-on-surface group-focus-within:group-hover:border-primary group-has-disabled:border-outline/[.12] group-has-disabled:group-hover:border-outline/[.12] group-error:border-error group-error:group-focus-within:border-error group-error:group-hover:border-on-error-container group-error:group-hover:group-focus-within:border-error ease-effects-fast duration-effects-fast pointer-events-none absolute -top-[0.71875rem] right-0 bottom-0 left-0 rounded-xs border px-[0.625rem] transition-all group-focus-within:border-2">
 				<legend
 					className={
-						"group-has-placeholder-shown:max-w-0 group-has-placeholder-shown:group-focus-within:max-w-none overflow-hidden whitespace-nowrap opacity-0 transition-all"
+						"overflow-hidden whitespace-nowrap opacity-0 transition-all group-has-placeholder-shown:max-w-0 group-has-placeholder-shown:group-focus-within:max-w-none"
 					}
 				>
-					<span className="text-body-sm group-has-required:after:content-['*'] px-1">
+					<span className="text-body-sm px-1 group-has-required:after:content-['*']">
 						{children}
 					</span>
 				</legend>

--- a/apps/web/app/components/Tooltip.tsx
+++ b/apps/web/app/components/Tooltip.tsx
@@ -42,7 +42,7 @@ const tooltip = tv({
 	slots: { container: "" },
 	variants: {
 		variant: {
-			rich: { container: "bg-surface-container rounded-md px-4 pb-2 pt-3" },
+			rich: { container: "bg-surface-container rounded-md px-4 pt-3 pb-2" },
 		},
 	},
 })
@@ -105,7 +105,7 @@ export function TooltipPlainContainer(props: Ariakit.TooltipProps): ReactNode {
 					gutter={4}
 					alwaysVisible
 					{...props}
-					className="bg-inverse-surface text-body-sm text-inverse-on-surface rounded-xs flex min-h-6 items-center px-2"
+					className="bg-inverse-surface text-body-sm text-inverse-on-surface flex min-h-6 items-center rounded-xs px-2"
 					render={
 						<motion.div
 							initial={{ opacity: 0, y }}
@@ -120,6 +120,6 @@ export function TooltipPlainContainer(props: Ariakit.TooltipProps): ReactNode {
 }
 export function TouchTarget(): ReactNode {
 	return (
-		<span className="absolute left-1/2 top-1/2 h-[max(100%,3rem)] w-[max(100%,3rem)] -translate-x-1/2 -translate-y-1/2" />
+		<span className="absolute top-1/2 left-1/2 h-[max(100%,3rem)] w-[max(100%,3rem)] -translate-x-1/2 -translate-y-1/2" />
 	)
 }

--- a/apps/web/app/lib/button.ts
+++ b/apps/web/app/lib/button.ts
@@ -1,14 +1,14 @@
 import { tv } from "~/lib/tailwind-variants"
 
 export const btnIcon = tv({
-	base: "text-on-surface-variant i hover:state-hover focused:state-focus pressed:state-pressed relative h-10 w-10 select-none rounded-full bg-center p-2",
+	base: "text-on-surface-variant i hover:state-hover focused:state-focus pressed:state-pressed relative h-10 w-10 rounded-full bg-center p-2 select-none",
 	variants: { variant: { standard: "" } },
 	defaultVariants: { variant: "standard" },
 })
 
 export const createButton = tv({
 	slots: {
-		root: "text-label-lg hover:state-hover focus-visible:state-focus active:state-pressed aria-disabled:text-on-surface/[.38] aria-disabled:state-none data-active:state-pressed data-focus-visible:state-focus inline-flex h-10 min-w-[3rem] select-none items-center justify-center whitespace-nowrap rounded-[1.25rem] aria-disabled:cursor-not-allowed",
+		root: "text-label-lg hover:state-hover focus-visible:state-focus active:state-pressed aria-disabled:text-on-surface/[.38] aria-disabled:state-none data-active:state-pressed data-focus-visible:state-focus inline-flex h-10 min-w-[3rem] items-center justify-center rounded-[1.25rem] whitespace-nowrap select-none aria-disabled:cursor-not-allowed",
 		icon: "dummy i-[1.125rem] h-[1.125rem] w-[1.125rem]",
 	},
 	variants: {

--- a/apps/web/app/lib/dialog.tsx
+++ b/apps/web/app/lib/dialog.tsx
@@ -13,10 +13,10 @@ export const createDialog = tv(
 		variants: {
 			variant: {
 				basic: {
-					root: "inset-[3.5rem] m-auto h-fit max-h-[calc(100%-7rem)] w-fit min-w-[17.5rem] max-w-[35rem] rounded-xl py-6",
+					root: "inset-[3.5rem] m-auto h-fit max-h-[calc(100%-7rem)] w-fit max-w-[35rem] min-w-[17.5rem] rounded-xl py-6",
 					content: "gap-6",
 					backdrop:
-						"bg-scrim/40 data-enter:opacity-100 opacity-0 transition-[opacity] ease-effects-slow duration-effects-slow",
+						"bg-scrim/40 ease-effects-slow duration-effects-slow opacity-0 transition-[opacity] data-enter:opacity-100",
 					headline:
 						"text-headline-sm -mb-2 h-auto px-6 text-center first:text-start",
 					body: "pt-0",

--- a/apps/web/app/lib/entry/Behind.ts
+++ b/apps/web/app/lib/entry/Behind.ts
@@ -6,7 +6,8 @@ const { graphql } = ReactRelay
 
 /**
  * @RelayResolver MediaList.behind: Int
- * @rootFragment Behind_entry*/
+ * @rootFragment Behind_entry
+ */
 export function behind(data: Behind_entry$key): null | number {
 	const entry = readFragment(
 		graphql`

--- a/apps/web/app/lib/entry/MediaCover.tsx
+++ b/apps/web/app/lib/entry/MediaCover.tsx
@@ -9,7 +9,7 @@ const { graphql } = ReactRelay
 import { tv } from "~/lib/tailwind-variants"
 
 const cover = tv({
-	base: "in-[.transitioning]:[view-transition-name:media-cover] bg-cover bg-center object-cover object-center",
+	base: "bg-cover bg-center object-cover object-center in-[.transitioning]:[view-transition-name:media-cover]",
 })
 
 import * as Ariakit from "@ariakit/react"

--- a/apps/web/app/lib/entry/Progress.tsx
+++ b/apps/web/app/lib/entry/Progress.tsx
@@ -88,7 +88,7 @@ export function ProgressIncrement(props: {
 		<div className="flex justify-end">
 			{Predicate.isString(data?.Viewer?.name)
 				&& data.Viewer.name === params.userName && (
-					<Form className="@md:block hidden" method="post">
+					<Form className="hidden @md:block" method="post">
 						<input type="hidden" name="progress" value={progress + 1} />
 						<input type="hidden" name="id" value={entry.id} />
 						<input type="hidden" name="intent" value="increment" />

--- a/apps/web/app/lib/entry/ToWatch.ts
+++ b/apps/web/app/lib/entry/ToWatch.ts
@@ -7,7 +7,8 @@ const { graphql } = ReactRelay
 
 /**
  * @RelayResolver MediaList.toWatch: Int
- * @rootFragment ToWatch_entry*/
+ * @rootFragment ToWatch_entry
+ */
 export function toWatch(data: ToWatch_entry$key): null | number {
 	const entry = readFragment(
 		graphql`

--- a/apps/web/app/lib/list/MediaList.tsx
+++ b/apps/web/app/lib/list/MediaList.tsx
@@ -56,7 +56,7 @@ export function MediaListHeaderToWatch(props: {
 }
 export function MediaListHeader(props: { children: ReactNode }): ReactNode {
 	return (
-		<div className="grid grid-flow-col items-center gap-4 [grid-auto-columns:minmax(0,1fr)]">
+		<div className="grid [grid-auto-columns:minmax(0,1fr)] grid-flow-col items-center gap-4">
 			{props.children}
 		</div>
 	)

--- a/apps/web/app/lib/media/Avalible.ts
+++ b/apps/web/app/lib/media/Avalible.ts
@@ -8,7 +8,8 @@ const { graphql } = ReactRelay
 
 /**
  * @RelayResolver Media.avalible: Int
- * @rootFragment Avalible_media*/
+ * @rootFragment Avalible_media
+ */
 export function avalible(key: Avalible_media$key): null | number | undefined {
 	const media = readFragment(
 		graphql`

--- a/apps/web/app/lib/media/Theme.ts
+++ b/apps/web/app/lib/media/Theme.ts
@@ -6,7 +6,8 @@ const { graphql } = ReactRelay
 
 /**
  * @RelayResolver MediaCoverImage.theme: RelayResolverValue
- * @rootFragment Theme_mediaCover*/
+ * @rootFragment Theme_mediaCover
+ */
 export function theme(key: Theme_mediaCover$key): null | Theme {
 	const media = readFragment(
 		graphql`

--- a/apps/web/app/lib/menu.tsx
+++ b/apps/web/app/lib/menu.tsx
@@ -1,8 +1,8 @@
 import { tv } from "~/lib/tailwind-variants"
 export const createMenu = tv({
 	slots: {
-		root: "bg-surface-container text-label-lg text-on-surface rounded-xs flex flex-col overflow-auto overscroll-contain py-2",
+		root: "bg-surface-container text-label-lg text-on-surface flex flex-col overflow-auto overscroll-contain rounded-xs py-2",
 		item: "bg-surface-container text-label-lg text-on-surface hover:state-hover focus:state-focus group flex h-12 items-center gap-3 px-3",
 	},
-	variants: { size: { full: { root: "min-w-[7rem] max-w-[17.5rem]" } } },
+	variants: { size: { full: { root: "max-w-[17.5rem] min-w-[7rem]" } } },
 })

--- a/apps/web/app/lib/textField.ts
+++ b/apps/web/app/lib/textField.ts
@@ -5,7 +5,7 @@ export const createTextField = tv({
 		variant: {
 			outlined: {
 				input:
-					"text-body-lg text-on-surface caret-primary focus:placeholder-on-surface-variant disabled:text-on-surface/[.38] group-error:caret-error [&_option]:bg-surface-container [&_option]:text-on-surface peer flex min-w-0 flex-1 resize-none items-center justify-between bg-transparent p-4 placeholder-transparent placeholder:transition-all group-has-[.suffix]:text-right group-has-[.suffix]:[appearance:textfield] [&::-webkit-inner-spin-button]:group-has-[.suffix]:hidden ease-effects-fast duration-effects-fast",
+					"text-body-lg text-on-surface caret-primary focus:placeholder-on-surface-variant disabled:text-on-surface/[.38] group-error:caret-error [&_option]:bg-surface-container [&_option]:text-on-surface peer ease-effects-fast duration-effects-fast flex min-w-0 flex-1 resize-none items-center justify-between bg-transparent p-4 placeholder-transparent group-has-[.suffix]:[appearance:textfield] group-has-[.suffix]:text-right placeholder:transition-all [&::-webkit-inner-spin-button]:group-has-[.suffix]:hidden",
 				root: "group relative mt-[10px] flex items-center",
 			},
 		},

--- a/apps/web/app/routes/Home/route.tsx
+++ b/apps/web/app/routes/Home/route.tsx
@@ -97,7 +97,7 @@ export default function Index({ loaderData }: Route.ComponentProps): ReactNode {
 																alt=""
 																loading="lazy"
 																src={activity.user.avatar.large}
-																className="bg-(image:--bg) h-10 w-10 rounded-full bg-cover object-cover"
+																className="h-10 w-10 rounded-full bg-(image:--bg) bg-cover object-cover"
 																style={
 																	activity.user.avatar.medium
 																		? {

--- a/apps/web/app/routes/Media/route.tsx
+++ b/apps/web/app/routes/Media/route.tsx
@@ -246,7 +246,7 @@ function Edit() {
 	const root = useRouteLoaderData<typeof rootLoader>("root")
 
 	return (
-		<motion.div layoutId="edit" className="fixed bottom-24 end-4 sm:bottom-4">
+		<motion.div layoutId="edit" className="fixed end-4 bottom-24 sm:bottom-4">
 			<div className="relative">
 				<TooltipPlain store={store}>
 					<TooltipPlainTrigger

--- a/apps/web/app/routes/Notifications/ActivityLike.tsx
+++ b/apps/web/app/routes/Notifications/ActivityLike.tsx
@@ -65,7 +65,7 @@ export function ActivityLike(props: {
 					{notification.user.avatar?.large ? (
 						<img
 							src={notification.user.avatar.large}
-							className="bg-(image:--bg) h-14 w-14 bg-cover object-cover"
+							className="h-14 w-14 bg-(image:--bg) bg-cover object-cover"
 							style={
 								notification.user.avatar.medium
 									? { "--bg": `url(${notification.user.avatar.medium})` }

--- a/apps/web/app/routes/Notifications/route.tsx
+++ b/apps/web/app/routes/Notifications/route.tsx
@@ -100,7 +100,7 @@ export default function Page({ loaderData }: Route.ComponentProps): ReactNode {
 			<LayoutPane>
 				{someNotRead ? (
 					<Form method="post">
-						<div className="fixed bottom-24 end-4 sm:bottom-4">
+						<div className="fixed end-4 bottom-24 sm:bottom-4">
 							<div className="relative">
 								<TooltipPlain store={store}>
 									<TooltipPlainTrigger

--- a/apps/web/app/routes/User/user-profile-theme-resolver.ts
+++ b/apps/web/app/routes/User/user-profile-theme-resolver.ts
@@ -6,7 +6,8 @@ const { graphql } = ReactRelay
 
 /**
  * @RelayResolver UserOptions.profileTheme: RelayResolverValue
- * @rootFragment userProfileThemeResolver_userOptions*/
+ * @rootFragment userProfileThemeResolver_userOptions
+ */
 export function profileTheme(
 	key: userProfileThemeResolver_userOptions$key
 ): null | Theme {

--- a/apps/web/desktop/remix-electron.js
+++ b/apps/web/desktop/remix-electron.js
@@ -2,7 +2,7 @@ import { resolve } from "node:path"
 
 /** @typedef {import("react-router").AppLoadContext} AppLoadContext */
 /** @typedef {import("react-router").ServerBuild} ServerBuild */
-/** @import { HttpBindings } from "@hono/node-server" */
+/** @import {HttpBindings} from "@hono/node-server" */
 
 /**
  * @typedef {object} InitRemixOptions
@@ -12,8 +12,8 @@ import { resolve } from "node:path"
  *   production
  * @property {string} [publicFolder] The path where static assets are served
  *   from.
- * @property {()=> import('react-router').RouterContextProvider} [getLoadContext] A function to provide a
- *   `context` object to your loaders.
+ * @property {() => import("react-router").RouterContextProvider} [getLoadContext]
+ *   A function to provide a `context` object to your loaders.
  */
 
 import { serve } from "@hono/node-server"

--- a/apps/web/graphql.config.js
+++ b/apps/web/graphql.config.js
@@ -1,2 +1,2 @@
-/** @type {import('graphql-config').IGraphQLConfig} */
+/** @type {import("graphql-config").IGraphQLConfig} */
 export default { schema: "./schema.graphql", documents: "./app/**/*.{ts,tsx}" }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig, devices } from "@playwright/test"
 import type { Fixtures } from "./tests/fixtures"
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+/** See https://playwright.dev/docs/test-configuration. */
 export default defineConfig<Fixtures>({
 	testDir: "./tests",
 	timeout: 60000,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"lint": "eslint --max-warnings 0 --cache . --fix",
 		"eslint-typegen": "node --import=tsx eslint.config.ts",
 		"dev": "turbo watch dev",
-		"format": "prettier . -w --cache --experimental-cli",
+		"format": "oxfmt && prettier . -w --cache --experimental-cli",
 		"bench": "turbo run --log-prefix=none bench --affected",
 		"test": "vitest --run --changed origin/master",
 		"test-e2e": "turbo run --log-prefix=none test-e2e --continue=dependencies-successful --log-order=stream",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"eslint-plugin-pnpm": "catalog:",
 		"eslint-typegen": "catalog:",
 		"knip": "catalog:",
+		"oxfmt": "catalog:",
 		"oxlint": "catalog:",
 		"oxlint-config": "workspace:*",
 		"oxlint-tsgolint": "catalog:",

--- a/packages/eslint-plugin-relay/src/rule-must-colocate-fragment-spreads.ts
+++ b/packages/eslint-plugin-relay/src/rule-must-colocate-fragment-spreads.ts
@@ -1,30 +1,32 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of thttps://github.com/relayjs/eslint-plugin-relay.
+ * This source code is licensed under the MIT license found in the LICENSE file
+ * in the root directory of thttps://github.com/relayjs/eslint-plugin-relay.
  *
  * This rule lints for non-colocated fragment spreads within queries or
  * fragments. In other words, situations where a fragment is spread in module A,
- * but the module (B) that defines that fragment is not imported by module A.
- * It does not lint subscriptions or mutations. This catches:
+ * but the module (B) that defines that fragment is not imported by module A. It
+ * does not lint subscriptions or mutations. This catches:
  *
  * - The anti-pattern of spreading a fragment in a parent module, then passing
- * that data down to a child module, or jamming it all in context. This defeats
- * the purpose of Relay. From the
- * [Relay docs](https://relay.dev/docs/next) – "[Relay]
- * allows components to specify what data they need and the Relay framework
- * provides the data. This makes the data needs of inner components opaque and
- * allows composition of those needs."
+ *   that data down to a child module, or jamming it all in context. This
+ *   defeats the purpose of Relay. From the [Relay
+ *   docs](https://relay.dev/docs/next) – "[Relay] allows components to specify
+ *   what data they need and the Relay framework provides the data. This makes
+ *   the data needs of inner components opaque and allows composition of those
+ *   needs."
  * - Instances where fragment spreads are unused, which results in overfetching.
  *
  * ## When the fragment is unused
+ *
  * The easiest way to tell if a fragment is unused is to remove the line
  * containing the lint error, run Relay compiler, then Flow. If there are no
  * type errors, then the fragment was possibly unused. You should still test
  * your functionality to see that it's working as expected.
  *
  * ## When the fragment is being passed to a child component
+ *
  * If you received Relay or Flow errors after attempting to remove the fragment,
  * then it's very likely that you're passing that data down the tree. Our
  * recommendation is to have components specify the data they need. In the below
@@ -32,23 +34,10 @@
  * no longer opaque. Component B should not be fetching data on Component C's
  * behalf.
  *
- * function ComponentA(props) {
- *   const data = useFragment(graphql`
- *     fragment ComponentA_fragment on User {
- *       foo
- *       bar
- *       some_field {
- *         ...ComponentC_fragment
- *       }
- *     }
- *   `);
- *   return (
- *     <div>
- *       {data.foo} {data.baz}
- *       <ComponentB text="Hello" data={data.some_field} />
- *     </div>
- *   );
- * }
+ * Function ComponentA(props) { const data = useFragment(graphql` fragment
+ * ComponentA_fragment on User { foo bar some_field { ...ComponentC_fragment } }
+ * `); return ( <div> {data.foo} {data.baz} <ComponentB text="Hello"
+ * data={data.some_field} /> </div> ); }
  *
  * To address this, refactor Component C to fetch the data it needs. You'll need
  * to update the intermediate components by amending, or adding a fragment to

--- a/packages/eslint-plugin-relay/src/rule-unused-fields.ts
+++ b/packages/eslint-plugin-relay/src/rule-unused-fields.ts
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of https://github.com/relayjs/eslint-plugin-relay.
+ * This source code is licensed under the MIT license found in the LICENSE file
+ * in the root directory of https://github.com/relayjs/eslint-plugin-relay.
  */
 
 import type { Rule } from "eslint"

--- a/packages/eslint-plugin-relay/src/utils.ts
+++ b/packages/eslint-plugin-relay/src/utils.ts
@@ -17,9 +17,7 @@ export interface NodeWithLoc {
 	loc: { end: number; start: number }
 }
 
-/**
- * Returns a range object for auto fixers.
- */
+/** Returns a range object for auto fixers. */
 function getRange(
 	context: Rule.RuleContext,
 	templateNode: GraphqlTemplateExpression,
@@ -32,9 +30,7 @@ function getRange(
 	]
 }
 
-/**
- * Returns a loc object for error reporting.
- */
+/** Returns a loc object for error reporting. */
 export function getLoc(
 	context: Rule.RuleContext,
 	templateNode: GraphqlTemplateExpression,

--- a/packages/unstyled/src/unstyled-use-styles.tsx
+++ b/packages/unstyled/src/unstyled-use-styles.tsx
@@ -2,9 +2,7 @@ import { useMemo, type ReactNode } from "react"
 import { invariant, numberToString } from "utilities"
 import { print, type PreCompiledStyles } from "./unstyled-print"
 
-/**
- * @internal
- */
+/** @internal */
 export function useStyles(rawStyle: PreCompiledStyles): [string, ReactNode] {
 	return useMemo(() => {
 		const styles = print(rawStyle)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ catalogs:
     nodemon:
       specifier: 3.1.14
       version: 3.1.14
+    oxfmt:
+      specifier: 0.47.0
+      version: 0.47.0
     oxlint:
       specifier: 1.56.0
       version: 1.56.0
@@ -359,6 +362,9 @@ importers:
       node:
         specifier: runtime:^24.14.1
         version: runtime:24.15.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.47.0
       oxlint:
         specifier: 'catalog:'
         version: 1.56.0(oxlint-tsgolint@0.21.1)
@@ -2729,6 +2735,128 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxfmt/binding-android-arm-eabi@0.47.0':
+    resolution: {integrity: sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.47.0':
+    resolution: {integrity: sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.47.0':
+    resolution: {integrity: sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.47.0':
+    resolution: {integrity: sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.47.0':
+    resolution: {integrity: sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
+    resolution: {integrity: sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
+    resolution: {integrity: sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
+    resolution: {integrity: sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.47.0':
+    resolution: {integrity: sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
+    resolution: {integrity: sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
+    resolution: {integrity: sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
+    resolution: {integrity: sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
+    resolution: {integrity: sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.47.0':
+    resolution: {integrity: sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.47.0':
+    resolution: {integrity: sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.47.0':
+    resolution: {integrity: sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
+    resolution: {integrity: sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
+    resolution: {integrity: sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.47.0':
+    resolution: {integrity: sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -5937,6 +6065,11 @@ packages:
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
+  oxfmt@0.47.0:
+    resolution: {integrity: sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   oxlint-tsgolint@0.21.1:
     resolution: {integrity: sha512-O2hxiT14C2HJkwzBU6CQBFPoagSd/IcV+Tt3e3UUaXFwbW4BO5DSDPSSboc3UM5MIDY+MLyepvtQwBQafNxWdw==}
     hasBin: true
@@ -6697,6 +6830,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -8735,6 +8872,63 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    optional: true
+
+  '@oxfmt/binding-android-arm-eabi@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.47.0':
     optional: true
 
   '@oxlint-tsgolint/darwin-arm64@0.21.1':
@@ -12074,6 +12268,30 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  oxfmt@0.47.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.47.0
+      '@oxfmt/binding-android-arm64': 0.47.0
+      '@oxfmt/binding-darwin-arm64': 0.47.0
+      '@oxfmt/binding-darwin-x64': 0.47.0
+      '@oxfmt/binding-freebsd-x64': 0.47.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.47.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.47.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.47.0
+      '@oxfmt/binding-linux-arm64-musl': 0.47.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.47.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.47.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.47.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.47.0
+      '@oxfmt/binding-linux-x64-gnu': 0.47.0
+      '@oxfmt/binding-linux-x64-musl': 0.47.0
+      '@oxfmt/binding-openharmony-arm64': 0.47.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.47.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.47.0
+      '@oxfmt/binding-win32-x64-msvc': 0.47.0
+
   oxlint-tsgolint@0.21.1:
     optionalDependencies:
       '@oxlint-tsgolint/darwin-arm64': 0.21.1
@@ -12895,6 +13113,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,6 +89,7 @@ catalog:
   motion: 12.38.0
   msw: 2.13.6
   nodemon: 3.1.14
+  oxfmt: 0.47.0
   oxlint: 1.56.0
   oxlint-tsgolint: 0.21.1
   prettier: 3.8.1
@@ -115,18 +116,18 @@ catalog:
   vite-plugin-relay: 2.1.0
   vitest: 4.1.5
   wrangler: 4.85.0
+catalogMode: strict
+cleanupUnusedCatalogs: true
 # trustPolicy: no-downgrade
 # trustPolicyIgnoreAfter: 4320
 dedupePeers: true
+enablePrePostScripts: false
 nodeLinker: hoisted
+optimisticRepeatInstall: true
 
 patchedDependencies:
   flubber: patches/flubber.patch
 
 savePrefix: ''
 shellEmulator: true
-enablePrePostScripts: false
-catalogMode: strict
-cleanupUnusedCatalogs: true
 verifyDepsBeforeRun: install
-optimisticRepeatInstall: true

--- a/stryker.config.js
+++ b/stryker.config.js
@@ -1,4 +1,4 @@
-/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+/** @type {import("@stryker-mutator/api/core").PartialStrykerOptions} */
 export default {
 	_comment:
 		"This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information.",


### PR DESCRIPTION
## Summary by Sourcery

Integrate the oxfmt formatter into the repo and apply automated formatting updates across config, JS/TS source, and styling utilities.

Enhancements:
- Reformat Tailwind class names, layout utilities, and component styles for consistency without changing behavior.
- Normalize JSDoc and comment formatting across the codebase, including Relay resolver annotations and import type references.

Build:
- Add oxfmt to the pnpm workspace catalog, lockfile, and root package.json format script alongside prettier.
- Introduce an .oxfmtrc.json configuration file for the oxfmt formatter and adjust pnpm workspace settings ordering.

Chores:
- Regenerate pnpm-lock.yaml to reflect new tooling and dependency catalog entries.