### PR TITLE
chore(ts-config): enable erasableOnly compiler option

### DIFF
--- a/apps/web/tests/pages/MediaPage.ts
+++ b/apps/web/tests/pages/MediaPage.ts
@@ -5,8 +5,7 @@ import { Nav } from "./Nav"
 export class MediaPage {
 	nav: Nav
 	title: Locator
-
-	private constructor(private readonly page: Page) {
+	private constructor(page: Page) {
 		this.nav = new Nav(page)
 		const main = page.getByRole("main")
 		this.title = main.getByRole("heading")

--- a/apps/web/tests/pages/SearchPage.ts
+++ b/apps/web/tests/pages/SearchPage.ts
@@ -5,7 +5,7 @@ export class SearchPage {
 	dialog: Locator
 	options: Locator
 	search: Locator
-	private constructor(private readonly page: Page) {
+	private constructor( page: Page) {
 		this.dialog = page.getByRole("dialog")
 		this.options = this.dialog.getByRole("option")
 		this.active = this.options.and(

--- a/apps/web/tests/pages/SearchPage.ts
+++ b/apps/web/tests/pages/SearchPage.ts
@@ -5,7 +5,7 @@ export class SearchPage {
 	dialog: Locator
 	options: Locator
 	search: Locator
-	private constructor( page: Page) {
+	private constructor(page: Page) {
 		this.dialog = page.getByRole("dialog")
 		this.options = this.dialog.getByRole("option")
 		this.active = this.options.and(

--- a/apps/web/tests/pages/TypelistPage.ts
+++ b/apps/web/tests/pages/TypelistPage.ts
@@ -3,7 +3,7 @@ import { Nav } from "./Nav"
 
 export class TypelistPage {
 	nav: Nav
-	private constructor(private readonly page: Page) {
+	private constructor( page: Page) {
 		this.nav = new Nav(page)
 	}
 	static async new(page: Page): Promise<TypelistPage> {

--- a/apps/web/tests/pages/TypelistPage.ts
+++ b/apps/web/tests/pages/TypelistPage.ts
@@ -3,7 +3,7 @@ import { Nav } from "./Nav"
 
 export class TypelistPage {
 	nav: Nav
-	private constructor( page: Page) {
+	private constructor(page: Page) {
 		this.nav = new Nav(page)
 	}
 	static async new(page: Page): Promise<TypelistPage> {

--- a/apps/web/tests/typelist.spec.ts
+++ b/apps/web/tests/typelist.spec.ts
@@ -16,7 +16,7 @@ import { TypelistPage } from "./pages/TypelistPage"
 class UserPage {
 	animeList: Locator
 	mangaList: Locator
-	private constructor(private readonly page: Page) {
+	private constructor(page: Page) {
 		this.animeList = page
 			.getByRole("main")
 			.getByRole("tab", { name: "Anime list" })

--- a/packages/ts-config/src/tsconfig.json
+++ b/packages/ts-config/src/tsconfig.json
@@ -17,7 +17,7 @@
 		"strict": true,
 		// "noUnusedLocals": true,
 		// "noUnusedParameters": true,
-		// "erasableSyntaxOnly": true,
+		"erasableSyntaxOnly": true,
 		"noUncheckedIndexedAccess": true,
 		"noImplicitOverride": true,
 		"noFallthroughCasesInSwitch": true,

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -4,11 +4,10 @@ import type { Value } from "./unstyled-value"
 
 export declare const PreCompiledStylesBrand: unique symbol
 export class PreCompiledStyles {
-	constructor(
-		/** @internal */ public readonly styles: {
-			[K in keyof Properties]?: string
-		}
-	) {}
+	/** @internal */ public readonly styles: { [K in keyof Properties]?: string }
+	constructor(styles: { [K in keyof Properties]?: string }) {
+		this.styles = styles
+	}
 }
 
 export function mergeStyles(


### PR DESCRIPTION
## Summary by Sourcery

Enable TypeScript's erasableSyntaxOnly option and adjust code to avoid using parameter properties in constructors.

Enhancements:
- Refactor classes to replace constructor parameter properties with explicit readonly fields assignments to satisfy erasableSyntaxOnly constraints.

Build:
- Enable the erasableSyntaxOnly TypeScript compiler option in the shared tsconfig.