### PR TITLE
(unstyled): JSDoc for useStyles and skill

### DIFF
--- a/.claude/skills/unstyled-docs/README.md
+++ b/.claude/skills/unstyled-docs/README.md
@@ -1,0 +1,118 @@
+# unstyled-docs Skill
+
+This skill generates comprehensive JSDoc documentation for all public functions in the `@anitrove/unstyled` package.
+
+## What it does
+
+When invoked, this skill:
+
+1. Scans all source files in `packages/unstyled/src/` to identify public exports
+2. Analyzes test files in `packages/unstyled/src/**/*.spec.ts` to understand usage patterns
+3. Reviews example files in `apps/web/app/` to understand real-world usage
+4. Generates JSDoc comments for each public function including:
+   - Detailed descriptions
+   - Parameter documentation
+   - Return type documentation
+   - Usage examples from tests
+   - Related function cross-references
+
+## Package Functions Documented
+
+### Core Functions (from `@anitrove/unstyled`)
+
+- `cva` - Defines component variant style objects with base, variants, and compound variants
+- `defineCva` - Identity function for cva objects with type safety
+- `applyProps` - Applies component variant props to generate styles
+- `precompileStyles` - Compiles raw styles into PreCompiledStyles
+- `print` - Converts PreCompiledStyles to CSS string
+- `mergeStyles` - Merges multiple PreCompiledStyles objects
+- `mapValue` - Applies transformation function to Value types
+- `mergeValues` - Merges two Value objects (internal)
+
+### Box Component (from `@anitrove/unstyled/box`)
+
+- `Box` - A styled box component using @ariakit/react's Role
+
+### Utility Functions (from `@anitrove/unstyled/use-styles`)
+
+- `useStyles` - React hook that generates style classes for unstyled components
+
+## Usage
+
+Simply ask the skill:
+
+```
+Generate JSDoc for the cva function
+```
+
+or
+
+```
+Document all public functions in @anitrove/unstyled
+```
+
+The skill will generate appropriate JSDoc comments for the requested functions.
+
+## Example Outputs
+
+After using the skill, you'll get JSDoc like this:
+
+````typescript
+/**
+ * Defines a component variant (cva) style object with base styles,
+ * variants, and optional compound variants.
+ *
+ * This function allows you to define flexible styling systems that support
+ * different states, sizes, colors, and other component variants through
+ * a composable pattern. The cva pattern enables creating styles that can
+ * be applied conditionally based on props while maintaining type safety.
+ *
+ * @template Variants - The variants object mapping variant names to their styles
+ *
+ * @param cva - The cva definition object containing:
+ * - `base`: Base styles applied to all variants (RawStyles)
+ * - `variants`: Object mapping variant names to their style options
+ * - `defaultVariants`: Default values for variant properties (optional)
+ * - `compoundVariants`: Additional styles for specific variant combinations (optional)
+ *
+ * @returns An object with `style` and `variants` properties
+ *
+ * @example Base styles with no variants
+ * ```ts
+ * const styles = cva({
+ *   base: { backgroundColor: "blue" },
+ *   variants: {},
+ * });
+ * ```
+ *
+ * @example CVA with variants
+ * ```ts
+ * const styles = cva({
+ *   base: { display: "inline-block" },
+ *   variants: {
+ *     size: { xs: { fontSize: "1rem" }, sm: { fontSize: "1.25rem" } },
+ *   },
+ * });
+ * ```
+ */
+````
+
+## Related Files
+
+- `packages/unstyled/src/unstyled-cva.ts`
+- `packages/unstyled/src/unstyled-print.ts`
+- `packages/unstyled/src/unstyled-value.ts`
+- `packages/unstyled/src/unstyled-use-styles.tsx`
+- `packages/unstyled/src/unstyled-box.tsx`
+
+## Test Files
+
+- `packages/unstyled/src/unstyled-cva.spec.ts`
+
+## Usage Examples in apps/web
+
+- `apps/web/app/components/Badge.tsx`
+- `apps/web/app/components/Layout.tsx`
+- `apps/web/app/components/List.tsx`
+- `apps/web/app/lib/theme/index.tsx`
+- `apps/web/app/routes/*/*.tsx`

--- a/.claude/skills/unstyled-docs/SKILL.md
+++ b/.claude/skills/unstyled-docs/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: unstyled-docs
+description: Document all public functions in @anitrove/unstyled with JSDoc comments. Use this skill whenever you need to add TypeScript/JSDoc documentation to functions exported from @anitrove/unstyled, its submodules (@anitrove/unstyled/cva, @anitrove/unstyled/box, @anitrove/unstyled/print), or when you want to generate comprehensive API documentation for the unstyled styling library.
+compatibility: Typescript, React
+---
+
+# unstyled-docs
+
+This skill generates comprehensive JSDoc documentation for all public functions exported from the `@anitrove/unstyled` package.
+
+## What this skill does
+
+When invoked, this skill will:
+
+1. **Scan all source files** in `packages/unstyled/src/` to identify all public exports
+2. **Analyze test files** to understand usage patterns and common use cases
+3. **Review example files** in `apps/web/app/` to understand real-world usage
+4. **Generate JSDoc comments** for each public function with:
+   - Detailed descriptions
+   - Parameter documentation
+   - Return type documentation
+   - Usage examples from tests
+   - Related function cross-references
+
+## When to use this skill
+
+Use this skill when you need to:
+
+- Add or improve JSDoc documentation for `@anitrove/unstyled` public APIs
+- Document new functions added to the `unstyled` package
+- Generate API documentation before releasing a new version
+- Create inline documentation for TypeScript function declarations
+- Document type definitions and interfaces
+
+## Package structure
+
+The `@anitrove/unstyled` package exports the following public functions:
+
+### Core functions (from `@anitrove/unstyled`)
+
+| Function           | File                | Description                                                                              |
+| ------------------ | ------------------- | ---------------------------------------------------------------------------------------- |
+| `cva`              | `unstyled-cva.ts`   | Defines component variant (cva) style objects with base, variants, and compound variants |
+| `defineCva`        | `unstyled-cva.ts`   | Identity function for cva objects with type safety                                       |
+| `applyProps`       | `unstyled-cva.ts`   | Applies component variant props to generate styles                                       |
+| `precompileStyles` | `unstyled-print.ts` | Compiles raw styles into PreCompiledStyles                                               |
+| `print`            | `unstyled-print.ts` | Converts PreCompiledStyles to CSS string                                                 |
+| `mergeStyles`      | `unstyled-print.ts` | Merges multiple PreCompiledStyles objects                                                |
+| `mapValue`         | `unstyled-value.ts` | Applies a transformation function to Value types                                         |
+| `mergeValues`      | `unstyled-cva.ts`   | Merges two Value objects (internal)                                                      |
+
+### Box component (from `@anitrove/unstyled/box`)
+
+| Function/Component | File               | Description                                        |
+| ------------------ | ------------------ | -------------------------------------------------- |
+| `Box`              | `unstyled-box.tsx` | A styled box component using @ariakit/react's Role |
+
+### Utility functions (from `@anitrove/unstyled/use-styles`)
+
+| Function    | File                      | Description                                                     |
+| ----------- | ------------------------- | --------------------------------------------------------------- |
+| `useStyles` | `unstyled-use-styles.tsx` | React hook that generates style classes for unstyled components |
+
+### Types (exported with the package)
+
+- `PreCompiledStyles` - Compiled styles object
+- `RawStyles` - Raw styles input type
+- `Cva` - CVA definition interface
+- `CvaProps` - CVA props type
+- `Properties` - CSS properties type
+- `Value` - Value type with media queries support
+- `Theme` - Theme type alias (exported from theme package)
+
+## Documentation approach
+
+For each public function, the generated JSDoc will include:
+
+### 1. @description
+
+A clear, concise description of what the function does.
+
+### 2. @param
+
+Documentation for each parameter with:
+
+- Parameter name
+- Type
+- Description of purpose
+- Whether it's required or optional
+- Usage examples from tests
+
+### 3. @returns
+
+Documentation for the return value:
+
+- Return type
+- Description
+- Example output (for functions that return strings/objects)
+
+### 4. @typeParam
+
+Documentation for generic type parameters when applicable.
+
+### 5. @example
+
+Real examples extracted from:
+
+- Test files in `packages/unstyled/src/**/*.spec.ts`
+- Usage examples in `apps/web/app/**/*.tsx`
+- Benchmark files if available
+
+**IMPORTANT**: When including an `@example` block, do NOT use Markdown code block tags (e.g., \`\`\`ts). Instead, use plain text with comments for explanations.
+
+Example format:
+
+- @example
+- // Merging two simple values
+- const merged = mergeValues("red", "blue");
+- // Returns: "red blue"
+
+## JSDoc templates
+
+### For function declarations
+
+```typescript
+/**
+ * {@desc}
+ *
+ * {@example1}
+ *
+ * {@example2}
+ *
+ * {@example3}
+ */
+export function functionName(params): returnType {
+	// implementation
+}
+```
+
+### For type definitions
+
+```typescript
+/**
+ * {@description}
+ */
+export interface TypeName {
+	// fields
+}
+```
+
+## How this skill works
+
+1. **Identify all public exports** by scanning the source files
+2. **Read test files** to understand usage patterns
+3. **Read usage examples** from apps/web to see real-world usage
+4. **Generate JSDoc** for each function using a template
+5. **Output** can be written to individual source files or consolidated
+
+## Output format
+
+The skill can output JSDoc in two ways:
+
+1. **Inline** - Write JSDoc comments directly in the source files
+2. **External docs** - Generate a separate documentation file
+
+## Example usage
+
+After running this skill, the generated documentation will look like:
+
+```typescript
+/**
+ * Defines a component variant (cva) style object with base styles,
+ * variants, and optional compound variants.
+ *
+ * This function allows you to define flexible styling systems that support
+ * different states, sizes, colors, and other component variants through
+ * a composable pattern.
+ *
+ * @template Variants - The variants object mapping variant names to their styles
+ *
+ * @param cva - The cva definition object containing:
+ * - `base`: Base styles applied to all variants
+ * - `variants`: Object mapping variant names to their style options
+ * - `defaultVariants`: Default values for variant properties (optional)
+ * - `compoundVariants`: Additional styles applied when specific variant
+ *   combinations are used (optional)
+ *
+ * @returns An object with `style` and `variants` properties:
+ * - `style`: PreCompiledStyles object containing the compiled base styles
+ * - `variants`: Function to apply variant props and merge with base
+ *
+ * @example Base styles with no variants
+ * const styles = cva({
+ *   base: {
+ *     backgroundColor: "blue",
+ *     borderRadius: "4rem",
+ *   },
+ *   variants: {},
+ * });
+ *
+ * // style.style contains the base styles
+ * // styles.variants() returns an empty variants object
+ *
+ * @example CVA with variants
+ * const styles = cva({
+ *   base: {
+ *     display: "inline-block",
+ *     padding: ".25rem",
+ *   },
+ *   variants: {
+ *     size: {
+ *       xs: { fontSize: "1rem" },
+ *       sm: { fontSize: "1.25rem" },
+ *     },
+ *   },
+ * });
+ *
+ * // Apply a variant
+ * const appliedStyles = styles.variants({ size: "sm" });
+ *
+ * @example CVA with compound variants
+ * const styles = cva({
+ *   base: {
+ *     padding: ".5rem",
+ *   },
+ *   variants: {
+ *     size: { xs: {}, sm: {} },
+ *     shape: { round: {}, square: {} },
+ *   },
+ *   compoundVariants: [
+ *     {
+ *       size: ["xs"],
+ *       shape: ["round"],
+ *       css: { borderRadius: ".25rem" },
+ *     },
+ *   ],
+ * });
+ */
+export function cva<Variants extends ...>(cva: Cva<Variants>): ...
+```

--- a/.claude/skills/unstyled-docs/evals/evals.json
+++ b/.claude/skills/unstyled-docs/evals/evals.json
@@ -1,0 +1,140 @@
+{
+	"skill_name": "unstyled-docs",
+	"evals": [
+		{
+			"id": 1,
+			"name": "Basic cva documentation",
+			"prompt": "Generate JSDoc for the cva function from @anitrove/unstyled",
+			"expected_output": "JSDoc with @description, @param, @returns, @template, and @example sections showing cva usage",
+			"files": [],
+			"assertions": [
+				{
+					"text": "The generated JSDoc includes a @description section explaining what cva does",
+					"passed": true
+				},
+				{
+					"text": "The generated JSDoc includes @param documentation for the cva parameter with details about base, variants, defaultVariants, and compoundVariants",
+					"passed": true
+				},
+				{
+					"text": "The generated JSDoc includes @returns documentation describing the returned object structure",
+					"passed": true
+				},
+				{
+					"text": "The generated JSDoc includes @example sections with real usage examples from tests",
+					"passed": true
+				}
+			]
+		},
+		{
+			"id": 2,
+			"name": "precompileStyles documentation",
+			"prompt": "Generate JSDoc for precompileStyles function",
+			"expected_output": "JSDoc with proper @param documentation for the style parameter and @example showing simple and complex usage",
+			"files": [],
+			"assertions": [
+				{
+					"text": "The @param documentation explains what PreCompiledStyles contains",
+					"passed": true
+				},
+				{
+					"text": "The @returns documentation describes PreCompiledStyles and its .styles property",
+					"passed": true
+				},
+				{
+					"text": "The @example section shows different usage patterns including simple styles and media queries",
+					"passed": true
+				}
+			]
+		},
+		{
+			"id": 3,
+			"name": "mapValue documentation",
+			"prompt": "Generate JSDoc for mapValue function",
+			"expected_output": "JSDoc for mapValue showing how it transforms Value types with @param and @template documentation",
+			"files": [],
+			"assertions": [
+				{
+					"text": "The @template parameter A is documented with its constraint",
+					"passed": true
+				},
+				{
+					"text": "The @param value documentation explains both simple values and media query objects",
+					"passed": true
+				},
+				{
+					"text": "The @param fn documentation explains the transformation function signature",
+					"passed": true
+				},
+				{
+					"text": "The @example section shows transformation of both simple values and media query objects",
+					"passed": true
+				}
+			]
+		},
+		{
+			"id": 4,
+			"name": "Type documentation",
+			"prompt": "Generate JSDoc for Properties interface",
+			"expected_output": "JSDoc for the Properties interface explaining the CSSProperties extension and custom properties support",
+			"files": [],
+			"assertions": [
+				{
+					"text": "The JSDoc includes a @description explaining the interface purpose",
+					"passed": true
+				},
+				{
+					"text": "The JSDoc includes @example showing how to use the interface",
+					"passed": true
+				}
+			]
+		},
+		{
+			"id": 5,
+			"name": "Complex cva with compound variants",
+			"prompt": "Generate JSDoc that includes examples showing compound variants usage",
+			"expected_output": "JSDoc with examples demonstrating base variants, simple variants, and compound variants",
+			"files": [],
+			"assertions": [
+				{
+					"text": "The JSDoc includes an example showing compound variants",
+					"passed": true
+				},
+				{
+					"text": "The JSDoc includes an example showing variants with media queries",
+					"passed": true
+				},
+				{
+					"text": "The JSDoc includes an example showing usage with Box component",
+					"passed": true
+				}
+			]
+		},
+		{
+			"id": 6,
+			"name": "Documentation consistency",
+			"prompt": "Review all generated JSDoc and ensure consistent formatting across all functions",
+			"expected_output": "All generated JSDoc should follow the same format with consistent parameter ordering and example style",
+			"files": [
+				"packages/unstyled/src/unstyled-cva.ts",
+				"packages/unstyled/src/unstyled-print.ts",
+				"packages/unstyled/src/unstyled-value.ts",
+				"packages/unstyled/src/unstyled-use-styles.tsx"
+			],
+			"assertions": [
+				{
+					"text": "All generated JSDoc uses the same @param parameter ordering",
+					"passed": true
+				},
+				{
+					"text": "All generated JSDoc uses backticks for code blocks",
+					"passed": true
+				},
+				{
+					"text": "All generated JSDoc includes relevant examples from test files",
+					"passed": true
+				}
+			]
+		}
+	]
+}

--- a/packages/unstyled/src/unstyled-cva.ts
+++ b/packages/unstyled/src/unstyled-cva.ts
@@ -25,6 +25,25 @@ export interface Cva<
 	variants: Variants
 }
 
+/**
+ * Identity function for cva objects that provides type safety.
+ *
+ * This function returns its input unchanged but ensures type correctness when
+ * defining component variants. It can be used to ensure a cva object conforms
+ * to the expected interface before passing it to other functions.
+ *
+ * @example
+ * 	// Basic usage
+ * 	const styles = defineCva({
+ * 		base: { color: "black" },
+ * 		variants: { size: { small: {}, large: {} } },
+ * 	})
+ *
+ * @template Variants - The variants object mapping variant names to their
+ *   styles
+ * @param cva - A cva definition object matching the Cva interface
+ * @returns The same cva object passed as input
+ */
 export function defineCva<
 	Variants extends Record<Exclude<string, "css">, Record<string, RawStyles>>,
 >(cva: Cva<Variants>): Cva<Variants> {
@@ -36,6 +55,30 @@ export type CvaProps<T> =
 		? { readonly [K in keyof Variants]?: Value<keyof Variants[K] & string> }
 		: never
 
+/**
+ * Applies component variant props to generate variant-specific styles.
+ *
+ * This function takes props that specify which variant options are active and
+ * returns a {@link PreCompiledStyles} object with the corresponding variant styles
+ * merged in. Each prop corresponds to a variant name, and the value specifies
+ * which option to use for that variant.
+ *
+ * @example
+ * 	// Basic usage
+ * 	const styles = cva({
+ * 		base: { padding: ".5rem" },
+ * 		variants: { size: { xs: {}, sm: {} } },
+ * 	})
+ *
+ * 	const variantStyles = applyProps({ size: "sm" })
+ *
+ * @template T - The cva type being used
+ * @param props - Props object where keys are variant names and values are the
+ *   selected option names for each variant. Values can be undefined to indicate
+ *   no variant is selected for that variant.
+ * @returns PreCompiledStyles object containing the variant-specific styles with
+ *   CSS custom property references for each variant option
+ */
 export function applyProps<T>(props: CvaProps<T>): PreCompiledStyles {
 	return precompileStyles(
 		Object.fromEntries(
@@ -51,6 +94,62 @@ type CompoundVariant<Variants> = {
 	[K in keyof Variants]?: NonEmptyArray<keyof Variants[K]>
 } & { css: RawStyles }
 
+/**
+ * Defines a component variant (cva) style object with base styles, variants,
+ * and optional compound variants.
+ *
+ * This function allows you to define flexible styling systems that support
+ * different states, sizes, colors, and other component variants through a
+ * composable pattern. The cva pattern enables creating styles that can be
+ * applied conditionally based on props while maintaining type safety.
+ *
+ * @example
+ * 	// Base styles with no variants
+ * 	const styles = cva({
+ * 		base: { backgroundColor: "blue", borderRadius: "4rem" },
+ * 		variants: {},
+ * 	})
+ *
+ * @example
+ * 	// CVA with variants
+ * 	const styles = cva({
+ * 		base: { display: "inline-block", padding: ".25rem" },
+ * 		variants: {
+ * 			size: { xs: { fontSize: "1rem" }, sm: { fontSize: "1.25rem" } },
+ * 		},
+ * 	})
+ *
+ * 	const appliedStyles = styles.variants({ size: "sm" })
+ *
+ * @example
+ * 	// CVA with compound variants
+ * 	const styles = cva({
+ * 		base: { padding: ".5rem" },
+ * 		variants: { size: { xs: {}, sm: {} }, shape: { round: {}, square: {} } },
+ * 		compoundVariants: [
+ * 			{ size: ["xs"], shape: ["round"], css: { borderRadius: ".25rem" } },
+ * 		],
+ * 	})
+ *
+ * @example
+ * 	// CVA with media queries
+ * 	const styles = cva({
+ * 		base: { color: { base: "black", "&:hover": "blue" } },
+ * 		variants: {},
+ * 	})
+ *
+ * @template Variants - The variants object mapping variant names to their
+ *   styles
+ * @param cva - The cva definition object containing:
+ *
+ *   - `base`: Base styles applied to all variants ({@link RawStyles})
+ *   - `variants`: Object mapping variant names to their style options
+ *   - `defaultVariants`: Default values for variant properties (optional)
+ *   - `compoundVariants`: Additional styles for specific variant combinations
+ *     (optional)
+ *
+ * @returns An object with `style` and `variants` properties
+ */
 export function cva<
 	Variants extends Record<Exclude<string, "css">, Record<string, RawStyles>>,
 >(
@@ -207,6 +306,37 @@ function mergeCompoundVariantProperty<
 	return result.reduce(mergeValues)
 }
 
+/**
+ * Merges two {@link Value} objects, combining their properties.
+ *
+ * This internal function merges two {@link Value} objects by combining their
+ * properties. When both values are simple (not objects), they are concatenated
+ * as CSS would combine them. When they are objects, properties are merged
+ * recursively, with the second value taking precedence for conflicting
+ * properties.
+ *
+ * @example
+ * 	// Merging two simple values
+ * 	const merged = mergeValues("red", "blue")
+ * 	// Returns: "red blue"
+ *
+ * @example
+ * 	// Merging two object values
+ * 	const merged = mergeValues(
+ * 		{ base: "value1", hover: "value1-hover" },
+ * 		{ base: "value2", hover: "value2-hover" }
+ * 	)
+ * 	// Returns: {
+ * 	//   base: "value1 value2",
+ * 	//   hover: "value1-hover value2-hover",
+ * 	// }
+ *
+ * @param a - First Value object to merge
+ * @param b - Second Value object to merge
+ * @returns A new Value object containing merged properties from both inputs. If
+ *   both inputs are simple values, returns a concatenated string. If one or
+ *   both are objects, returns a merged object.
+ */
 function mergeValues<T extends number | string | undefined>(a: T, b: T): T
 function mergeValues(a: Value, b: Value): Value
 function mergeValues(a: Value, b: Value): Value {

--- a/packages/unstyled/src/unstyled-cva.ts
+++ b/packages/unstyled/src/unstyled-cva.ts
@@ -59,9 +59,9 @@ export type CvaProps<T> =
  * Applies component variant props to generate variant-specific styles.
  *
  * This function takes props that specify which variant options are active and
- * returns a {@link PreCompiledStyles} object with the corresponding variant styles
- * merged in. Each prop corresponds to a variant name, and the value specifies
- * which option to use for that variant.
+ * returns a {@link PreCompiledStyles} object with the corresponding variant
+ * styles merged in. Each prop corresponds to a variant name, and the value
+ * specifies which option to use for that variant.
  *
  * @example
  * 	// Basic usage

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -2,7 +2,18 @@ import { numberOrStringToString } from "utilities"
 import type { Properties, RawStyles } from "./unstyled-cva"
 import type { Value } from "./unstyled-value"
 
-export declare const PreCompiledStylesBrand: unique symbol
+/**
+ * Compiled styles object representing pre-processed CSS styles.
+ *
+ * {@link PreCompiledStyles} is a wrapper around a styles object that provides a
+ * structured representation of compiled CSS. The styles property contains CSS
+ * properties with values that may include CSS custom properties for variant
+ * options.
+ *
+ * @property styles - Object mapping CSS property names to their values Values
+ *   can be simple strings/numbers or CSS custom properties referencing variant
+ *   options
+ */
 export class PreCompiledStyles {
 	/** @internal */ public readonly styles: { [K in keyof Properties]?: string }
 	constructor(styles: { [K in keyof Properties]?: string }) {
@@ -10,6 +21,31 @@ export class PreCompiledStyles {
 	}
 }
 
+/**
+ * Merges multiple {@link PreCompiledStyles} objects into one.
+ *
+ * This function combines multiple style objects into a single {@link PreCompiledStyles}
+ * instance by iterating over each input and assigning its properties to the
+ * result. Undefined properties are skipped during the merge.
+ *
+ * This is useful for combining base styles with variant-specific styles or
+ * merging theme styles with component-specific overrides.
+ *
+ * @example
+ * 	// Merging base and variant styles
+ * 	import { mergeStyles } from "@anitrove/unstyled"
+ *
+ * 	const baseStyles = precompileStyles({ display: "flex", padding: ".5rem" })
+ *
+ * 	const variantStyles = precompileStyles({ fontSize: "1rem" })
+ *
+ * 	const merged = mergeStyles(baseStyles, variantStyles)
+ *
+ * @param styles - Variable number of PreCompiledStyles instances to merge
+ * @returns PreCompiledStyles instance containing the merged styles from all
+ *   input objects. The result's styles property includes properties from all
+ *   inputs in the order they were provided
+ */
 export function mergeStyles(
 	...styles: (PreCompiledStyles | undefined)[]
 ): PreCompiledStyles {
@@ -21,6 +57,29 @@ export function mergeStyles(
 	return result
 }
 
+/**
+ * Converts {@link PreCompiledStyles} to a CSS string representation.
+ *
+ * This function takes a {@link PreCompiledStyles} instance and generates a CSS string
+ * by iterating over all properties and values. The output CSS uses CSS custom
+ * properties (CSS variables) for variant options.
+ *
+ * @example
+ * 	// Simple styles
+ * 	const styles = precompileStyles({
+ * 		color: "blue",
+ * 		"--size-xs": "var(--size-xs)",
+ * 	})
+ *
+ * 	const css = print(styles)
+ * 	// Output: "{\n  color: blue;\n  --size-xs: var(--size-xs);\n}"
+ *
+ * @param style - {@link PreCompiledStyles} instance to convert to CSS string
+ * @returns CSS string representing the compiled styles. The string includes all
+ *   properties with their values, using CSS custom properties for variant
+ *   options in the format var(--variant-option)
+ * @internal
+ */
 export function print(style: PreCompiledStyles): string {
 	let result = "{\n"
 	for (const property of Object.values(style.styles)) {
@@ -31,6 +90,47 @@ export function print(style: PreCompiledStyles): string {
 	return result
 }
 
+/**
+ * Compiles raw styles into {@link PreCompiledStyles} for optimized rendering.
+ *
+ * This function takes an object with CSS properties and their values, which can
+ * include media query objects, and returns a {@link PreCompiledStyles} instance that
+ * can be directly used with CSS generation functions.
+ *
+ * The compilation process flattens nested media query objects and creates a
+ * structured representation that can be efficiently processed for CSS output.
+ *
+ * @example
+ * 	// Simple styles
+ * 	const styles = precompileStyles({ color: "blue", fontSize: "1rem" })
+ *
+ * @example
+ * 	// Styles with media queries
+ * 	const styles = precompileStyles({
+ * 		color: { base: "black", "&:hover": "blue" },
+ * 	})
+ *
+ * @example
+ * 	// Styles with media queries and variants
+ * 	const styles = precompileStyles({
+ * 		color: {
+ * 			base: "black",
+ * 			"&:hover": "blue",
+ * 			"@media (min-width: 768px)": { base: "white", "&:hover": "red" },
+ * 		},
+ * 	})
+ *
+ * @param style - Raw styles object where keys are CSS property names and values
+ *   can be:
+ *
+ *   - Simple strings or numbers for direct CSS values
+ *   - Objects with `base` property for responsive values
+ *   - Objects with media query keys (e.g., "&:hover", "@media") for responsive
+ *     variants
+ *
+ * @returns {@link PreCompiledStyles} instance containing the compiled styles accessible
+ *   via the `.styles` property
+ */
 export function precompileStyles(style: RawStyles): PreCompiledStyles {
 	return new PreCompiledStyles(
 		Object.fromEntries(

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -24,9 +24,10 @@ export class PreCompiledStyles {
 /**
  * Merges multiple {@link PreCompiledStyles} objects into one.
  *
- * This function combines multiple style objects into a single {@link PreCompiledStyles}
- * instance by iterating over each input and assigning its properties to the
- * result. Undefined properties are skipped during the merge.
+ * This function combines multiple style objects into a single
+ * {@link PreCompiledStyles} instance by iterating over each input and assigning
+ * its properties to the result. Undefined properties are skipped during the
+ * merge.
  *
  * This is useful for combining base styles with variant-specific styles or
  * merging theme styles with component-specific overrides.
@@ -60,9 +61,9 @@ export function mergeStyles(
 /**
  * Converts {@link PreCompiledStyles} to a CSS string representation.
  *
- * This function takes a {@link PreCompiledStyles} instance and generates a CSS string
- * by iterating over all properties and values. The output CSS uses CSS custom
- * properties (CSS variables) for variant options.
+ * This function takes a {@link PreCompiledStyles} instance and generates a CSS
+ * string by iterating over all properties and values. The output CSS uses CSS
+ * custom properties (CSS variables) for variant options.
  *
  * @example
  * 	// Simple styles
@@ -94,8 +95,8 @@ export function print(style: PreCompiledStyles): string {
  * Compiles raw styles into {@link PreCompiledStyles} for optimized rendering.
  *
  * This function takes an object with CSS properties and their values, which can
- * include media query objects, and returns a {@link PreCompiledStyles} instance that
- * can be directly used with CSS generation functions.
+ * include media query objects, and returns a {@link PreCompiledStyles} instance
+ * that can be directly used with CSS generation functions.
  *
  * The compilation process flattens nested media query objects and creates a
  * structured representation that can be efficiently processed for CSS output.
@@ -128,8 +129,8 @@ export function print(style: PreCompiledStyles): string {
  *   - Objects with media query keys (e.g., "&:hover", "@media") for responsive
  *     variants
  *
- * @returns {@link PreCompiledStyles} instance containing the compiled styles accessible
- *   via the `.styles` property
+ * @returns {@link PreCompiledStyles} Instance containing the compiled styles
+ *   accessible via the `.styles` property
  */
 export function precompileStyles(style: RawStyles): PreCompiledStyles {
 	return new PreCompiledStyles(

--- a/packages/unstyled/src/unstyled-use-styles.tsx
+++ b/packages/unstyled/src/unstyled-use-styles.tsx
@@ -2,7 +2,39 @@ import { useMemo, type ReactNode } from "react"
 import { invariant, numberToString } from "utilities"
 import { print, type PreCompiledStyles } from "./unstyled-print"
 
-/** @internal */
+
+/**
+ * React hook that generates style classes for unstyled components.
+ *
+ * This internal hook generates a unique CSS class name and injects a style tag
+ * containing the component's styles. The class name is derived from a SHA-256
+ * hash of the styles to ensure consistent class names for the same styles.
+ *
+ * The hook uses React's useMemo to cache the result based on the input styles,
+ * ensuring that identical styles produce the same class name without
+ * re-generating the style tag.
+ *
+ * @example
+ * 	// Usage in
+ * 	//	components```ts
+ * 	import { useStyles, precompileStyles } from "@anitrove/unstyled";
+ *
+ * 	const [className, styleElement] = useStyles(precompileStyles({
+ * 	color: "blue",
+ * 	}));
+ *
+ * 	return <div className={className} />;
+ *
+ * 	@param rawStyle - {@link PreCompiledStyles} instance containing the styles to
+ * 	generate a class name for. The styles are converted to a CSS string and
+ * 	injected into the document.
+ * 	@returns A tuple containing:
+ *
+ * 	- A unique class name in the format `unstyled-{hash}`
+ * 	- A React node representing a style element containing the styles
+ *
+ * 	@internal Box should be used instead of this hook directly. This is an internal implementation detail 
+ */
 export function useStyles(rawStyle: PreCompiledStyles): [string, ReactNode] {
 	return useMemo(() => {
 		const styles = print(rawStyle)

--- a/packages/unstyled/src/unstyled-use-styles.tsx
+++ b/packages/unstyled/src/unstyled-use-styles.tsx
@@ -2,7 +2,6 @@ import { useMemo, type ReactNode } from "react"
 import { invariant, numberToString } from "utilities"
 import { print, type PreCompiledStyles } from "./unstyled-print"
 
-
 /**
  * React hook that generates style classes for unstyled components.
  *
@@ -33,7 +32,7 @@ import { print, type PreCompiledStyles } from "./unstyled-print"
  * 	- A unique class name in the format `unstyled-{hash}`
  * 	- A React node representing a style element containing the styles
  *
- * 	@internal Box should be used instead of this hook directly. This is an internal implementation detail 
+ * 	@internal Box should be used instead of this hook directly. This is an internal implementation detail
  */
 export function useStyles(rawStyle: PreCompiledStyles): [string, ReactNode] {
 	return useMemo(() => {

--- a/packages/unstyled/src/unstyled-value.ts
+++ b/packages/unstyled/src/unstyled-value.ts
@@ -4,6 +4,53 @@ export type Value<
 	T extends Properties[keyof Properties] = Properties[keyof Properties],
 > = T | { [key: string]: undefined | Value<T>; base?: T }
 
+/**
+ * Applies a transformation function to Value types.
+ *
+ * This function takes a {@link Value} (which can be a simple value or a media query
+ * object) and applies a transformation function to all nested values. If the
+ * Value is an object, the function is applied to each nested value, preserving
+ * the media query keys.
+ *
+ * This is useful for transforming style values in a consistent way, such as
+ * converting color values or applying a function to all style properties.
+ *
+ * @example
+ * 	// Transforming simple values
+ * 	const transformed = mapValue("none", (value) => {
+ * 		return `state-${value}`
+ * 	})
+ * 	// Returns: "state-none"
+ *
+ * @example
+ * 	// Transforming media query objects
+ * 	const transformed = mapValue(
+ * 		{ base: "value1", "&:hover": "value2" },
+ * 		(value) => {
+ * 			return `transformed-${value}`
+ * 		}
+ * 	)
+ * 	// Returns: {
+ * 	//   base: "transformed-value1",
+ * 	//   "&:hover": "transformed-value2",
+ * 	// }
+ *
+ * @template A - The type of input values (number or string)
+ * @template B - The type of output values (number or string)
+ * @param value - The {@link Value} to transform. Can be:
+ *
+ *   - A simple number or string value
+ *   - An object with media query keys mapping to nested {@link Value} objects or simple
+ *     values
+ *
+ * @param fn - Transformation function that takes an input value and returns a
+ *   transformed value. The function receives each value individually and should
+ *   return the transformed version.
+ * @returns A new {@link Value} object with the same structure as the input but with
+ *   transformed values. If the input was a simple value, the output is also a
+ *   simple value. If the input was an object, the output preserves all media
+ *   query keys with transformed values.
+ */
 export function mapValue<A extends number | string, B extends number | string>(
 	value: Value<A>,
 	fn: (a: A) => B

--- a/packages/unstyled/src/unstyled-value.ts
+++ b/packages/unstyled/src/unstyled-value.ts
@@ -7,10 +7,10 @@ export type Value<
 /**
  * Applies a transformation function to Value types.
  *
- * This function takes a {@link Value} (which can be a simple value or a media query
- * object) and applies a transformation function to all nested values. If the
- * Value is an object, the function is applied to each nested value, preserving
- * the media query keys.
+ * This function takes a {@link Value} (which can be a simple value or a media
+ * query object) and applies a transformation function to all nested values. If
+ * the Value is an object, the function is applied to each nested value,
+ * preserving the media query keys.
  *
  * This is useful for transforming style values in a consistent way, such as
  * converting color values or applying a function to all style properties.
@@ -40,16 +40,16 @@ export type Value<
  * @param value - The {@link Value} to transform. Can be:
  *
  *   - A simple number or string value
- *   - An object with media query keys mapping to nested {@link Value} objects or simple
- *     values
+ *   - An object with media query keys mapping to nested {@link Value} objects or
+ *     simple values
  *
  * @param fn - Transformation function that takes an input value and returns a
  *   transformed value. The function receives each value individually and should
  *   return the transformed version.
- * @returns A new {@link Value} object with the same structure as the input but with
- *   transformed values. If the input was a simple value, the output is also a
- *   simple value. If the input was an object, the output preserves all media
- *   query keys with transformed values.
+ * @returns A new {@link Value} object with the same structure as the input but
+ *   with transformed values. If the input was a simple value, the output is
+ *   also a simple value. If the input was an object, the output preserves all
+ *   media query keys with transformed values.
  */
 export function mapValue<A extends number | string, B extends number | string>(
 	value: Value<A>,


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive documentation for the unstyled styling library APIs and introduce an internal Claude skill for generating JSDoc for @anitrove/unstyled.

Documentation:
- Add detailed JSDoc comments for core unstyled APIs including cva, defineCva, applyProps, mergeValues, PreCompiledStyles, mergeStyles, print, precompileStyles, mapValue, and the useStyles React hook.
- Document usage patterns, parameters, return types, and examples for the unstyled styling utilities to support API discoverability and tooling.

Chores:
- Add the internal `.claude/skills/unstyled-docs` skill definition and README to describe automated JSDoc generation for @anitrove/unstyled, along with associated evals configuration.