### PR TITLE
(web): remove-only react-scan script tagRemove the dev-only injection the react-scan from theroot document to prevent loading an external script duringdevelopment. avoids accidental reliance on a global script,

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -127,12 +127,6 @@ export function Layout({ children }: { children: ReactNode }): ReactNode {
 				/> */}
 				<Meta />
 				<Links />
-				{import.meta.env.DEV ? (
-					<script
-						async
-						src="https://unpkg.com/react-scan/dist/auto.global.js"
-					></script>
-				) : null}
 			</head>
 			<body>
 				<RelayEnvironment environment={environment}>


### PR DESCRIPTION
reduces in the head and keeps behavior acrossenvironments.

Quiet local head nowNo external auto script loadsCleaner, safer dev

## Summary by Sourcery

Remove the development-only react-scan external script injection from the web app root layout to avoid loading a remote script tag during development.

Bug Fixes:
- Eliminate reliance on an external global react-scan script in development builds to prevent unintended dependencies and side effects.

Enhancements:
- Simplify the document head by removing unnecessary dev-time script tags for a cleaner and more consistent layout across environments.