### PR TITLE
New commit

### DIFF
--- a/apps/web/tests/auth.setup.ts
+++ b/apps/web/tests/auth.setup.ts
@@ -9,7 +9,7 @@ const env = invariant(type({ ANILIST_TEST_TOKEN: "string" })(process.env))
 
 setup("authenticate", async ({ page, baseURL }) => {
 	await page.goto(baseURL ?? "/")
-	await page.keyboard.press("Control+.")
+
 	const indexPage = await FeedPage.new(page)
 	const loginPage = await indexPage.nav.gotoLogin()
 	await loginPage.token.fill(env.ANILIST_TEST_TOKEN)

--- a/apps/web/tests/search.spec.ts
+++ b/apps/web/tests/search.spec.ts
@@ -65,7 +65,6 @@ test.fixme(true, "fix main page")
 test("when search, ArrowDown should change focus", async ({ page, worker }) => {
 	worker.use(...handlers)
 
-	await page.keyboard.press("Control+.")
 	await expect(page.getByTestId("hydrated")).toBeVisible()
 	await page.keyboard.press("Control+k")
 	const searchPage = SearchPage.new(page)
@@ -80,7 +79,6 @@ test("when search, ArrowDown should change focus", async ({ page, worker }) => {
 test("search", async ({ page, worker }) => {
 	worker.use(...handlers)
 
-	await page.keyboard.press("Control+.")
 	await expect(page.getByTestId("hydrated")).toBeVisible()
 	await page.keyboard.press("Control+k")
 	const searchPage = SearchPage.new(page)


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update auth.setup and search tests to assume the app is already hydrated without triggering the Control+. shortcut.