### PR TITLE
✨ feat: allow Fragment without data-key JSX tests

### DIFF
--- a/packages/eslint-plugin-jsx/src/rule-must-include-data-key.spec.ts
+++ b/packages/eslint-plugin-jsx/src/rule-must-include-data-key.spec.ts
@@ -62,6 +62,12 @@ void describe("rule-must-include-data-key", () => {
 		)
 	})
 
+	test("allows missing data-key for Fragment", async () => {
+		await valid(`
+        <Fragment key="foo" />
+        `)
+	})
+
 	test("reports error for missing data-key", async () => {
 		const { result } = await invalid({
 			code: `

--- a/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
+++ b/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
@@ -24,7 +24,10 @@ export const rule: RuleModule<string> = {
 		return {
 			JSXOpeningElement(node: TSESTree.JSXOpeningElement) {
 				// Skip <Fragment /> elements
-				if (node.name.type === AST_NODE_TYPES.JSXIdentifier && node.name.name === "Fragment") {
+				if (
+					node.name.type === AST_NODE_TYPES.JSXIdentifier
+					&& node.name.name === "Fragment"
+				) {
 					return
 				}
 

--- a/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
+++ b/packages/eslint-plugin-jsx/src/rule-must-include-data-key.ts
@@ -23,6 +23,11 @@ export const rule: RuleModule<string> = {
 	create(context: RuleContext<string, []>) {
 		return {
 			JSXOpeningElement(node: TSESTree.JSXOpeningElement) {
+				// Skip <Fragment /> elements
+				if (node.name.type === AST_NODE_TYPES.JSXIdentifier && node.name.name === "Fragment") {
+					return
+				}
+
 				const byName = Object.fromEntries(
 					node.attributes.flatMap(
 						(attribute): [string, TSESTree.JSXAttribute][] => {


### PR DESCRIPTION
## Summary by Sourcery

Allow JSX Fragment elements to be exempt from the must-include-data-key rule and cover this behavior with tests.

New Features:
- Permit JSX <Fragment> elements without a data-key attribute under the must-include-data-key lint rule.

Tests:
- Add a JSX rule test case ensuring <Fragment> without data-key is treated as valid input.