### PR TITLE
fix: quote renovate env values to numeric coercion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,5 +32,5 @@
 		// TODO: update
 		"dompurify"
 	],
-	"env": { "PNPM_MAX_WORKERS": 1, "pnpm_config_network_concurrency": 1 }
+	"env": { "PNPM_MAX_WORKERS": "1", "pnpm_config_network_concurrency": "1" }
 }


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/6g0kwtm3/codesmith/animini-monorepo/pr/1673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

## Summary by Sourcery

Enhancements:
- Adjust Renovate configuration to treat environment variable values as strings rather than implicitly coerced numbers.