### PR TITLE
✨ feat(media): add fixed cover image dimensions (230x320)

### DIFF
--- a/apps/web/app/lib/entry/MediaCover.tsx
+++ b/apps/web/app/lib/entry/MediaCover.tsx
@@ -60,6 +60,8 @@ export function MediaCover({ media, ...props }: MediaCoverProps): ReactNode {
 				.filter(Boolean)
 				.join(", ")}
 			alt=""
+			width={230}
+			height={320}
 			{...props}
 			style={{
 				backgroundImage: data.coverImage?.medium


### PR DESCRIPTION
## Summary by Sourcery

Set explicit fixed dimensions for media cover images in the web app to standardize their display size.