### PR TITLE
✨ chore: remove eslint/ters groupings from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,7 @@
 			"automerge": false
 		},
 		{ "groupName": "build", "extends": ["packages:vite"] },
-		{ "groupName": "test", "extends": ["packages:test"] },
-		{ "groupName": "linters", "extends": ["packages:linters"] },
-		{ "groupName": "eslint", "matchPackageNames": ["/eslint/"] }
+		{ "groupName": "test", "extends": ["packages:test"] }
 	],
 	"postUpdateOptions": ["pnpmDedupe"],
 	"automergeType": "branch",


### PR DESCRIPTION
## Summary by Sourcery

Update Renovate configuration to simplify dependency grouping.

Build:
- Adjust Renovate configuration by removing custom eslint/ters dependency groupings from renovate.json.

Chores:
- Clean up dependency update settings by relying on default Renovate grouping behavior.