### PR TITLE
🔧 refactor: defer window show until ready

### DIFF
--- a/apps/web/desktop/index.js
+++ b/apps/web/desktop/index.js
@@ -5,7 +5,7 @@ import { app, BrowserWindow, session } from "electron"
 import { RouterContextProvider } from "react-router"
 import { initRemix } from "./remix-electron.js"
 
-export { }
+export {}
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/apps/web/desktop/index.js
+++ b/apps/web/desktop/index.js
@@ -31,7 +31,6 @@ async function createWindow() {
 			),
 			getLoadContext: () => new RouterContextProvider(),
 		}))
-	void win.loadURL(url)
 
 	void win.once("ready-to-show", () => {
 		win.show()
@@ -40,6 +39,7 @@ async function createWindow() {
 	if (process.env.NODE_ENV === "development") {
 		win.webContents.openDevTools()
 	}
+	await win.loadURL(url)
 }
 
 void app.whenReady().then(async () => {

--- a/apps/web/desktop/index.js
+++ b/apps/web/desktop/index.js
@@ -5,7 +5,7 @@ import { app, BrowserWindow, session } from "electron"
 import { RouterContextProvider } from "react-router"
 import { initRemix } from "./remix-electron.js"
 
-export {}
+export { }
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -31,8 +31,11 @@ async function createWindow() {
 			),
 			getLoadContext: () => new RouterContextProvider(),
 		}))
-	await win.loadURL(url)
-	win.show()
+	void win.loadURL(url)
+
+	void win.once("ready-to-show", () => {
+		win.show()
+	})
 
 	if (process.env.NODE_ENV === "development") {
 		win.webContents.openDevTools()


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust window initialization to show the window only after the 'ready-to-show' event fires, avoiding premature display while content is loading.