### PR TITLE
🔧 Update build output paths from build to dist

### DIFF
--- a/apps/web/desktop/index.js
+++ b/apps/web/desktop/index.js
@@ -1,6 +1,6 @@
 import path, { dirname } from "node:path"
 import { fileURLToPath } from "node:url"
-
+import config from "../react-router.config.ts"
 import { app, BrowserWindow, session } from "electron"
 import { RouterContextProvider } from "react-router"
 import { initRemix } from "./remix-electron.js"
@@ -22,7 +22,13 @@ async function createWindow() {
 	url ??=
 		process.env.EXISTING_SERVER_URL
 		?? (await initRemix({
-			serverBuild: path.join(__dirname, "../build/server/index.js"),
+			buildDirectory: config.buildDirectory,
+			serverBuild: path.join(
+				__dirname,
+				"..",
+				config.buildDirectory,
+				"server/index.js"
+			),
 			getLoadContext: () => new RouterContextProvider(),
 		}))
 	await win.loadURL(url)

--- a/apps/web/desktop/remix-electron.js
+++ b/apps/web/desktop/remix-electron.js
@@ -11,6 +11,7 @@ import { resolve } from "node:path"
  * @property {string} [mode] The mode to run the app in, either development or
  *   production
  * @property {string} [publicFolder] The path where static assets are served
+ * @property {string} [buildDirectory] The path where the server build is output
  *   from.
  * @property {() => import("react-router").RouterContextProvider} [getLoadContext]
  *   A function to provide a `context` object to your loaders.
@@ -33,6 +34,7 @@ export async function initRemix({
 	mode,
 	publicFolder: _publicFolderOption = "public",
 	getLoadContext,
+	buildDirectory,
 }) {
 	await app.whenReady()
 
@@ -64,11 +66,13 @@ export async function initRemix({
 	} else {
 		void server.use(
 			"/assets",
-			serveStatic({ root: resolve(appRoot, "build/client/assets") })
+			serveStatic({ root: resolve(appRoot, buildDirectory, "client/assets") })
 		)
 	}
 
-	void server.use(serveStatic({ root: resolve(appRoot, "build/client") }))
+	void server.use(
+		serveStatic({ root: resolve(appRoot, buildDirectory, "client") })
+	)
 
 	const serverBuild = viteDevServer
 		? () =>

--- a/apps/web/eslint.config.ts
+++ b/apps/web/eslint.config.ts
@@ -13,7 +13,7 @@ export default typegen([
 		ignores: [
 			"app/gql/",
 			"app/paraglide/",
-			"public/build/",
+			"public/dist/",
 			"public/mockServiceWorker.js",
 			"**/schema.graphql",
 			".react-router/",

--- a/apps/web/nodemon.json
+++ b/apps/web/nodemon.json
@@ -2,5 +2,5 @@
 	"$schema": "https://json.schemastore.org/nodemon.json",
 	"exec": "electron",
 	"watch": ["desktop"],
-	"ignore": ["build", "public/build"]
+	"ignore": ["dist", "public/dist"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
 		"bundlewatch": "bundlewatch",
 		"check": "tsgo --noEmit",
 		"eslint-typegen": "node --import=tsx eslint.config.ts",
-		"deploy": "wrangler pages deploy ./build/client",
+		"deploy": "wrangler pages deploy ./dist/client",
 		"dev": "react-router dev",
 		"electron:dev": "nodemon .",
 		"electron:start": "electron .",


### PR DESCRIPTION
🔧 fix: update deploy path from build to dist

## Summary by Sourcery

Align the web app's desktop and deployment configuration with a new configurable build output directory.

New Features:
- Add support for configuring the Remix/Electron server build directory via a buildDirectory option.

Enhancements:
- Update the Electron desktop bootstrap to use the shared buildDirectory configuration for server builds and static asset paths.

Build:
- Change static asset and server build paths from build to a configurable buildDirectory, defaulting to dist, across desktop and deployment scripts.
- Update ESLint config to ignore the new dist-based public asset directory.
- Adjust the deploy script to publish from dist/client instead of build/client.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1685 
- <kbd>&nbsp;1&nbsp;</kbd> #1684 👈 
<!-- GitButler Footer Boundary Bottom -->

