### PR TITLE
🔧 Remove electron E2E test error handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,6 @@ jobs:
         run: sudo apt install -y xvfb
 
       - name: Test E2E
-        # TODO: fix electron
-        continue-on-error: ${{ matrix.project == 'electron' }}
         run: ${{ matrix.os == 'ubuntu-latest' && matrix.project == 'electron' && 'xvfb-run --auto-servernum' || '' }} pnpm -w test-e2e -- --project=${{ matrix.project }}*
         env:
           ELECTRON_DISABLE_SANDBOX: 1


### PR DESCRIPTION
<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1685 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1684 
<!-- GitButler Footer Boundary Bottom -->

## Summary by Sourcery

CI:
- Update test workflow to no longer continue on error for Electron E2E tests.