### PR TITLE
🔧 Add electron to onlyBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,6 +124,8 @@ dedupePeers: true
 enablePrePostScripts: false
 nodeLinker: hoisted
 optimisticRepeatInstall: true
+onlyBuiltDependencies:
+  - electron
 
 patchedDependencies:
   flubber: patches/flubber.patch


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update pnpm-workspace configuration to list electron under onlyBuiltDependencies for build handling.