### PR TITLE
🎭 Remove container, install playwright explicitly

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -22,7 +22,6 @@ concurrency:
 jobs:
   update-screenshots:
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-jammy
     # safety first: don't run on main
     if: github.ref_name != github.event.repository.default_branch
 
@@ -48,6 +47,9 @@ jobs:
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
 
+      - name: Install playwright 📦
+        run: pnpm --filter=web exec playwright install --with-deps
+
       - name: Configure Git
         run: |
           git config --global user.name "${{ env.AUTHOR_NAME }}"
@@ -57,7 +59,6 @@ jobs:
       - name: Update Visual Regression Screenshots
         run: pnpm -w test-e2e -- --project=web-mobile-chrome --update-snapshots
 
-      - run: git config --global --add safe.directory /__w/animini-monorepo/animini-monorepo
       # check what changed
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust the update-screenshots GitHub Actions workflow to drop the Playwright container and install Playwright with dependencies via pnpm during the job.