### PR TITLE
🔧 Remove path filters from workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,9 +6,6 @@ on:
       - master
       - renovate/**
   pull_request:
-    paths-ignore:
-      - ".claude/**"
-      - "**.md"
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -6,9 +6,6 @@ on:
       - master
       - renovate/**
   pull_request:
-    paths-ignore:
-      - ".claude/**"
-      - "**.md"
   # merge_group: # codespeed does not support merge groups
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,6 @@ on:
       - master
       - renovate/**
   pull_request:
-    paths-ignore:
-      - ".claude/**"
-      - "**.md"
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - renovate/**
   pull_request:
-    paths-ignore:
-      - ".claude/**"
-      - "**.md"
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
🔧 Refactor workflow triggers to use paths instead of paths-ignore

## Summary by Sourcery

CI:
- Remove pull_request paths-ignore filters from Chromatic, CodSpeed, deploy, and test workflows so they run on all PR changes.