### PR TITLE
add to list

### DIFF
--- a/apps/web/app/lib/entry/AddToList.tsx
+++ b/apps/web/app/lib/entry/AddToList.tsx
@@ -1,0 +1,164 @@
+import ReactRelay, { useMutation } from "react-relay"
+
+import MaterialSymbolsVisibilityOff from "~icons/material-symbols/visibility-off"
+
+import { CompositeItem } from "@ariakit/react"
+import { Button, ButtonIcon } from "~/components/Button"
+
+import type { AddToListMutation } from "~/gql/AddToListMutation.graphql"
+import type { AddToList_media$key } from "~/gql/AddToList_media.graphql"
+import type { AddToList_mediaListCollection$key } from "~/gql/AddToList_mediaListCollection.graphql"
+import type { AddToList_originalEntry$key } from "~/gql/AddToList_originalEntry.graphql"
+import type { AddToList_updatable$key } from "~/gql/AddToList_updatable.graphql"
+import { useFragment } from "../Network"
+
+const { graphql } = ReactRelay
+
+export function AddToList({
+	media: mediaKey,
+	originalEntry,
+	mediaListCollection: mediaListCollectionKey,
+}: {
+	media: AddToList_media$key
+	mediaListCollection: AddToList_mediaListCollection$key
+	originalEntry: AddToList_originalEntry$key
+}) {
+	const source = useFragment(
+		graphql`
+			fragment AddToList_originalEntry on MediaList {
+				id
+				private
+				status
+			}
+		`,
+		originalEntry
+	)
+
+	const mediaListCollection = useFragment(
+		graphql`
+			fragment AddToList_mediaListCollection on MediaListCollection {
+				lists {
+					...AddToList_updatable
+					status
+					entries {
+						id
+						...AddToList_assignable
+					}
+				}
+			}
+		`,
+		mediaListCollectionKey
+	)
+
+	const media = useFragment(
+		graphql`
+			fragment AddToList_media on Media {
+				id
+			}
+		`,
+		mediaKey
+	)
+
+	const [mutate, inFlight] = useMutation<AddToListMutation>(graphql`
+		mutation AddToListMutation(
+			$mediaId: Int!
+			$status: MediaListStatus!
+			$private: Boolean
+		) @raw_response_type {
+			SaveMediaListEntry(
+				mediaId: $mediaId
+				status: $status
+				private: $private
+			) {
+				id
+				status
+				...MediaListItem_entry
+				...AddToList_originalEntry
+				...SyncMedia_entry
+				...SyncMedia_source
+				...ProgressIncrement_entry
+				...AddToList_assignable
+				media {
+					id
+					...MediaListItem_media
+					...AddToList_media
+					relations {
+						edges {
+							id
+							relationType(version: 2)
+							node {
+								id
+								...MediaListItem_media
+								...AddToList_media
+							}
+						}
+					}
+				}
+			}
+		}
+	`)
+
+	return (
+		<form
+			className="flex justify-end"
+			action={() => {
+				void mutate({
+					variables: {
+						mediaId: media.id,
+						status: source.status ?? "PLANNING",
+						private: source.private,
+					},
+					// optimisticResponse: {
+					// 	SaveMediaListEntry: {
+					// 		__typename: "MediaList",
+					// 		id: Math.random(),
+					// 		status: source.status ?? "PLANNING",
+					// 		private: source.private,
+					// 	},
+					// },
+					updater: (store, response) => {
+						for (const list of mediaListCollection.lists ?? []) {
+							if (list != null && list.status === source.status) {
+								const { updatableData } =
+									store.readUpdatableFragment<AddToList_updatable$key>(
+										graphql`
+											fragment AddToList_updatable on MediaListGroup
+											@updatable {
+												entries {
+													id
+													...AddToList_assignable
+												}
+											}
+										`,
+										list
+									)
+
+								if (response?.SaveMediaListEntry != null) {
+									updatableData.entries = [
+										...(list.entries?.filter((entry) => entry != null) ?? []),
+										response.SaveMediaListEntry,
+									]
+								}
+							}
+						}
+					},
+				})
+			}}
+		>
+			<Button type="submit" render={<CompositeItem />} disabled={inFlight}>
+				Add to list
+				{source.private ? (
+					<ButtonIcon>
+						<MaterialSymbolsVisibilityOff></MaterialSymbolsVisibilityOff>
+					</ButtonIcon>
+				) : null}
+			</Button>
+		</form>
+	)
+}
+
+void graphql`
+	fragment AddToList_assignable on MediaList @assignable {
+		__typename
+	}
+`

--- a/apps/web/app/lib/entry/SyncMedia.tsx
+++ b/apps/web/app/lib/entry/SyncMedia.tsx
@@ -80,7 +80,7 @@ export function SyncMedia(props: {
 				id
 				status
 				...MediaListItem_entry
-				# ...AddToList_originalEntry
+				...AddToList_originalEntry
 				...SyncMedia_entry
 				...SyncMedia_source
 				...ProgressIncrement_entry
@@ -88,7 +88,7 @@ export function SyncMedia(props: {
 				media {
 					id
 					...MediaListItem_media
-					# ...AddToList_media
+					...AddToList_media
 					relations {
 						edges {
 							id
@@ -96,7 +96,7 @@ export function SyncMedia(props: {
 							node {
 								id
 								...MediaListItem_media
-								# ...AddToList_media
+								...AddToList_media
 							}
 						}
 					}

--- a/apps/web/app/routes/UserListSelected/route.tsx
+++ b/apps/web/app/routes/UserListSelected/route.tsx
@@ -34,8 +34,11 @@ import { captureException } from "@sentry/react"
 import { type } from "arktype"
 import { ExtraOutlet, ExtraOutlets } from "extra-outlet"
 import { BreadcrumbItem } from "~/components/Breadcrumb"
+import type { AddToList_media$key } from "~/gql/AddToList_media.graphql"
+import type { AddToList_originalEntry$key } from "~/gql/AddToList_originalEntry.graphql"
 import type { MediaListItem_media$key } from "~/gql/MediaListItem_media.graphql"
 import type { routeUserSetStatusMutation } from "~/gql/routeUserSetStatusMutation.graphql"
+import { AddToList } from "~/lib/entry/AddToList"
 import { ProgressIncrement } from "~/lib/entry/Progress"
 import { SyncMedia } from "~/lib/entry/SyncMedia"
 import { invariant } from "~/lib/invariant"
@@ -49,6 +52,7 @@ const NavUserListEntriesQuery = graphql`
 		MediaListCollection(userName: $userName, type: $type)
 			@required(action: LOG) {
 			...SyncMedia_mediaListCollection
+			...AddToList_mediaListCollection
 			lists {
 				name
 				entries {
@@ -58,9 +62,11 @@ const NavUserListEntriesQuery = graphql`
 					...SyncMedia_entry
 					...SyncMedia_source
 					...ProgressIncrement_entry
+					...AddToList_originalEntry
 					media @required(action: LOG) {
 						id
 						...MediaListItem_media
+						...AddToList_media
 						relations {
 							edges {
 								id
@@ -68,6 +74,7 @@ const NavUserListEntriesQuery = graphql`
 								node {
 									id
 									...MediaListItem_media
+									...AddToList_media
 								}
 							}
 						}
@@ -270,7 +277,7 @@ function AwaitList(props: Route.ComponentProps) {
 		>
 			{mediaList
 				.entries()
-				.map(([id, { media, relations }]) => {
+				.map(([id, { media, relations, originalEntry }]) => {
 					const entry = allEntries.get(id)
 
 					return (
@@ -305,7 +312,13 @@ function AwaitList(props: Route.ComponentProps) {
 												})()}
 											<ProgressIncrement entry={entry} />
 										</div>
-									) : null}
+									) : (
+										<AddToList
+											media={media}
+											originalEntry={originalEntry}
+											mediaListCollection={data.MediaListCollection}
+										></AddToList>
+									)}
 								</Skeleton>
 							</MediaListItem>
 							{relations
@@ -321,7 +334,15 @@ function AwaitList(props: Route.ComponentProps) {
 											style={precompileStyles({ marginBlockStart: "-.125rem" })}
 										>
 											<Skeleton>
-												{entry ? <ProgressIncrement entry={entry} /> : null}
+												{entry ? (
+													<ProgressIncrement entry={entry} />
+												) : (
+													<AddToList
+														media={node}
+														originalEntry={originalEntry}
+														mediaListCollection={data.MediaListCollection}
+													></AddToList>
+												)}
 											</Skeleton>
 										</MediaListItem>
 									)
@@ -374,9 +395,9 @@ export function ErrorBoundary(): ReactNode {
 	)
 }
 interface MediaListMapEntry {
-	media: MediaListItem_media$key
-	originalEntry: unknown
-	relations: Map<number, MediaListItem_media$key>
+	media: MediaListItem_media$key & AddToList_media$key
+	originalEntry: AddToList_originalEntry$key
+	relations: Map<number, MediaListItem_media$key & AddToList_media$key>
 }
 
 function mergeMapEntries(

--- a/apps/web/tests/pages/TypelistPage.ts
+++ b/apps/web/tests/pages/TypelistPage.ts
@@ -23,11 +23,13 @@ export class TypelistPage {
 }
 
 class MediaListItem {
+	public readonly addToList: Locator
 	public readonly privateBadge: Locator
 	public readonly progress: Locator
 	public readonly sync: Locator
 	constructor(locator: Locator) {
 		this.sync = locator.getByRole("button", { name: "Sync" })
+		this.addToList = locator.getByRole("button", { name: "Add to list" })
 		this.progress = locator.getByTestId("progress")
 		this.privateBadge = locator.getByTestId("private-badge")
 	}

--- a/apps/web/tests/typelist.spec.ts
+++ b/apps/web/tests/typelist.spec.ts
@@ -50,7 +50,7 @@ const handlers = [
 				data: {
 					SaveMediaListEntry: {
 						__typename: "MediaList",
-						status: variables.status ?? "CURRENT",
+						status: variables.status,
 						id: variables.mediaId,
 						completedAt: null,
 						private: variables.private,
@@ -391,10 +391,9 @@ test("add to list", async ({ page }) => {
 	const userpage = UserPage.new(page)
 	await userpage.mangaList.click()
 	const typelist = await TypelistPage.new(page)
-	const entry = typelist.entry(/Media title/)
 	const containedEntry = typelist.entry(/Contained media title/)
 	// when
-	await entry.addToList.click()
+	await containedEntry.addToList.click()
 	// then
 	await expect(containedEntry.progress).toHaveText(/0/)
 	await expect(containedEntry.privateBadge).toBeAttached()

--- a/apps/web/tests/typelist.spec.ts
+++ b/apps/web/tests/typelist.spec.ts
@@ -134,65 +134,6 @@ const handlers = [
 	graphql.query<
 		routeNavUserListEntriesQuery$rawResponse,
 		routeNavUserListEntriesQuery$variables
-	>(
-		"routeNavUserListEntriesQuery",
-		() =>
-			HttpResponse.json({
-				data: {
-					MediaListCollection: {
-						lists: [
-							{
-								__typename: "MediaListGroup",
-								status: "COMPLETED",
-								name: "List",
-								entries: [
-									{
-										__typename: "MediaList",
-										status: "COMPLETED",
-										id: 1,
-										completedAt: { day: 0, month: 1, year: 2 },
-										private: true,
-										progress: 12,
-										score: 2,
-										startedAt: { day: 1, month: 2, year: 3 },
-										media: {
-											id: 1,
-											title: { userPreferred: "Media title" },
-											type: "MANGA",
-											status: "FINISHED",
-											relations: {
-												edges: [
-													{
-														id: 100,
-														relationType: "CONTAINS",
-														node: {
-															id: 2,
-															title: { userPreferred: "Contained media title" },
-															coverImage: {
-																color: null,
-																large: null,
-																medium: null,
-															},
-														},
-													},
-												],
-											},
-											episodes: null,
-											coverImage: { color: null, large: null, medium: null },
-											chapters: 12,
-										},
-									},
-								],
-							},
-						],
-					},
-				},
-			}),
-		{ once: true }
-	),
-	graphql.query<
-		routeNavUserListEntriesQuery$rawResponse,
-		routeNavUserListEntriesQuery$variables
 	>("routeNavUserListEntriesQuery", () =>
 		HttpResponse.json({
 			data: {
@@ -239,42 +180,6 @@ const handlers = [
 										chapters: 12,
 									},
 								},
-								{
-									__typename: "MediaList",
-									status: "COMPLETED",
-									id: 2,
-									completedAt: { day: 0, month: 1, year: 2 },
-									private: true,
-									progress: 1,
-									score: 2,
-									startedAt: { day: 1, month: 2, year: 3 },
-									media: {
-										id: 2,
-										title: { userPreferred: "Contained media title" },
-										type: "MANGA",
-										status: "FINISHED",
-										relations: {
-											edges: [
-												{
-													id: 200,
-													relationType: "COMPILATION",
-													node: {
-														id: 1,
-														title: { userPreferred: "Media title" },
-														coverImage: {
-															color: null,
-															large: null,
-															medium: null,
-														},
-													},
-												},
-											],
-										},
-										episodes: null,
-										coverImage: { color: null, large: null, medium: null },
-										chapters: 1,
-									},
-								},
 							],
 						},
 					],
@@ -282,7 +187,6 @@ const handlers = [
 			},
 		})
 	),
-
 	graphql.query<routeNavUserQuery$rawResponse, routeNavUserQuery$variables>(
 		"routeNavUserQuery",
 		() =>

--- a/apps/web/tests/typelist.spec.ts
+++ b/apps/web/tests/typelist.spec.ts
@@ -3,6 +3,10 @@ import { expect } from "@playwright/test"
 import { type } from "arktype"
 import { graphql, HttpResponse } from "msw"
 import type {
+	AddToListMutation$rawResponse,
+	AddToListMutation$variables,
+} from "~/gql/AddToListMutation.graphql"
+import type {
 	SyncMediaMutation$rawResponse,
 	SyncMediaMutation$variables,
 } from "~/gql/SyncMediaMutation.graphql"
@@ -39,22 +43,70 @@ class UserPage {
 
 const Viewer = { id: 1, name: "User" }
 const handlers = [
-	graphql.mutation<SyncMediaMutation$rawResponse, SyncMediaMutation$variables>(
-		"SyncMediaMutation",
-		() =>
+	graphql.mutation<AddToListMutation$rawResponse, AddToListMutation$variables>(
+		"AddToListMutation",
+		({ variables }) =>
 			HttpResponse.json({
 				data: {
 					SaveMediaListEntry: {
 						__typename: "MediaList",
-						status: "COMPLETED",
-						id: 2,
-						completedAt: { day: 0, month: 1, year: 2 },
-						private: true,
-						progress: 1,
+						status: variables.status ?? "CURRENT",
+						id: variables.mediaId,
+						completedAt: null,
+						private: variables.private,
+						progress: 0,
 						score: 2,
 						startedAt: { day: 1, month: 2, year: 3 },
 						media: {
-							id: 2,
+							id: variables.mediaId,
+							title: { userPreferred: "Contained media title" },
+							type: "MANGA",
+							status: "FINISHED",
+							relations: {
+								edges: [
+									{
+										id: 200,
+										relationType: "COMPILATION",
+										node: {
+											id: 1,
+											title: { userPreferred: "Media title" },
+											coverImage: { color: null, large: null, medium: null },
+										},
+									},
+								],
+							},
+							episodes: null,
+							coverImage: { color: null, large: null, medium: null },
+							chapters: 1,
+						},
+					},
+				},
+			})
+	),
+	graphql.mutation<SyncMediaMutation$rawResponse, SyncMediaMutation$variables>(
+		"SyncMediaMutation",
+		({ variables }) =>
+			HttpResponse.json({
+				data: {
+					SaveMediaListEntry: {
+						__typename: "MediaList",
+						status: variables.status,
+						id: variables.mediaId,
+						completedAt: variables.completedAt && {
+							day: variables.completedAt.day,
+							month: variables.completedAt.month,
+							year: variables.completedAt.year,
+						},
+						private: variables.private,
+						progress: 1,
+						score: 2,
+						startedAt: variables.startedAt && {
+							day: variables.startedAt.day,
+							month: variables.startedAt.month,
+							year: variables.startedAt.year,
+						},
+						media: {
+							id: variables.mediaId,
 							title: { userPreferred: "Contained media title" },
 							type: "MANGA",
 							status: "FINISHED",
@@ -331,4 +383,19 @@ test("manga list", async ({ page }) => {
 	await userpage.mangaList.click()
 	// then
 	await TypelistPage.new(page)
+})
+
+test("add to list", async ({ page }) => {
+	const indexPage = await FeedPage.new(page)
+	await indexPage.nav.profile.click()
+	const userpage = UserPage.new(page)
+	await userpage.mangaList.click()
+	const typelist = await TypelistPage.new(page)
+	const entry = typelist.entry(/Media title/)
+	const containedEntry = typelist.entry(/Contained media title/)
+	// when
+	await entry.addToList.click()
+	// then
+	await expect(containedEntry.progress).toHaveText(/0/)
+	await expect(containedEntry.privateBadge).toBeAttached()
 })


### PR DESCRIPTION
## Summary by Sourcery

Add a Relay-powered "Add to list" entry form for media, wiring it to the SaveMediaListEntry mutation and updating the media list collection in the client store.

New Features:
- Introduce an AddToList React component that submits a SaveMediaListEntry mutation for a given media item.
- Display an "Add to list" button that reflects and preserves the original entry's privacy status, including a private icon indicator.