### PR TITLE
🧪 Move sync media test outside fullscreen block

### DIFF
--- a/apps/web/tests/typelist.spec.ts
+++ b/apps/web/tests/typelist.spec.ts
@@ -251,22 +251,6 @@ test.describe("fullscreen", () => {
 		// then
 		await TypelistPage.new(page)
 	})
-
-	test("sync media", async ({ page, isElectron, isMobile }) => {
-		test.skip(isMobile || isElectron)
-		const indexPage = await FeedPage.new(page)
-		await indexPage.nav.profile.click()
-		const userpage = UserPage.new(page)
-		await userpage.mangaList.click()
-		const typelist = await TypelistPage.new(page)
-		const entry = typelist.entry(/Media title/)
-		const containedEntry = typelist.entry(/Contained media title/)
-		// when
-		await entry.sync.click()
-		// then
-		await expect(containedEntry.progress).toHaveText(/1/)
-		await expect(containedEntry.privateBadge).toBeAttached()
-	})
 })
 
 test("anime list", async ({ page }) => {
@@ -300,5 +284,19 @@ test("add to list", async ({ page }) => {
 	await containedEntry.addToList.click()
 	// then
 	await expect(containedEntry.progress).toHaveText(/0/)
+	await expect(containedEntry.privateBadge).toBeAttached()
+})
+test("sync media", async ({ page }) => {
+	const indexPage = await FeedPage.new(page)
+	await indexPage.nav.profile.click()
+	const userpage = UserPage.new(page)
+	await userpage.mangaList.click()
+	const typelist = await TypelistPage.new(page)
+	const entry = typelist.entry(/Media title/)
+	const containedEntry = typelist.entry(/Contained media title/)
+	// when
+	await entry.sync.click()
+	// then
+	await expect(containedEntry.progress).toHaveText(/1/)
 	await expect(containedEntry.privateBadge).toBeAttached()
 })


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Relocate the sync media test from the fullscreen describe block into a standalone test to better reflect its scope.