### PR TITLE
🔧 upgrade eslint-plugin-oxlint to 1.63.0

### DIFF
--- a/apps/web/app/lib/entry/MediaListItem.tsx
+++ b/apps/web/app/lib/entry/MediaListItem.tsx
@@ -84,8 +84,7 @@ export function MediaListItem({
 	const data = useFragment(MediaListItem_media, mediaKey)
 
 	return (
-		<>
-			<ListItem
+		<ListItem
 				data-testid="media-list-item"
 				style={mergeStyles(
 					data.coverImage?.theme ?? undefined,
@@ -147,7 +146,6 @@ export function MediaListItem({
 				</ListItemContent>
 				{children}
 			</ListItem>
-		</>
 	)
 }
 

--- a/apps/web/app/lib/entry/MediaListItem.tsx
+++ b/apps/web/app/lib/entry/MediaListItem.tsx
@@ -85,67 +85,62 @@ export function MediaListItem({
 
 	return (
 		<ListItem
-				data-testid="media-list-item"
-				style={mergeStyles(
-					data.coverImage?.theme ?? undefined,
-					precompileStyles({
-						gridColumn: "1 / -1",
-						display: "grid",
-						gridTemplateColumns: "subgrid",
-						...utilities.theme({
-							[media.hover]: { default: "light", [media.dark]: "dark" },
-							[media.focusWithin]: { default: "light", [media.dark]: "dark" },
-						}),
-						...utilities.contrast({
-							[media.hover]: { default: "standard", [media.dark]: "high" },
-							[media.focusWithin]: {
-								default: "standard",
-								[media.dark]: "high",
-							},
-						}),
+			data-testid="media-list-item"
+			style={mergeStyles(
+				data.coverImage?.theme ?? undefined,
+				precompileStyles({
+					gridColumn: "1 / -1",
+					display: "grid",
+					gridTemplateColumns: "subgrid",
+					...utilities.theme({
+						[media.hover]: { default: "light", [media.dark]: "dark" },
+						[media.focusWithin]: { default: "light", [media.dark]: "dark" },
 					}),
-					props.style
-				)}
-				render={<CompositeRow></CompositeRow>}
+					...utilities.contrast({
+						[media.hover]: { default: "standard", [media.dark]: "high" },
+						[media.focusWithin]: { default: "standard", [media.dark]: "high" },
+					}),
+				}),
+				props.style
+			)}
+			render={<CompositeRow></CompositeRow>}
+		>
+			<Box style={precompileStyles({ position: "relative" })}>
+				<ListItemImg>
+					<Skeleton full>
+						<MediaCover media={data} />
+					</Skeleton>
+				</ListItemImg>
+				{entry?.private ? (
+					<Badge data-testid="private-badge">
+						<MaterialSymbolsVisibilityOff></MaterialSymbolsVisibilityOff>
+					</Badge>
+				) : null}
+			</Box>
+			<ListItemContent
+				render={
+					<CompositeItem render={<A href={route_media({ id: data.id })}></A>} />
+				}
 			>
-				<Box style={precompileStyles({ position: "relative" })}>
-					<ListItemImg>
-						<Skeleton full>
-							<MediaCover media={data} />
-						</Skeleton>
-					</ListItemImg>
-					{entry?.private ? (
-						<Badge data-testid="private-badge">
-							<MaterialSymbolsVisibilityOff></MaterialSymbolsVisibilityOff>
-						</Badge>
-					) : null}
-				</Box>
-				<ListItemContent
-					render={
-						<CompositeItem
-							render={<A href={route_media({ id: data.id })}></A>}
-						/>
-					}
+				<ListItemContentTitle>
+					<Skeleton>
+						<MediaTitle media={data}></MediaTitle>
+					</Skeleton>
+				</ListItemContentTitle>
+				<ListItemContentSubtitle
+					style={precompileStyles({
+						display: "flex",
+						flexWrap: "wrap",
+						gap: ".25rem",
+					})}
 				>
-					<ListItemContentTitle>
-						<Skeleton>
-							<MediaTitle media={data}></MediaTitle>
-						</Skeleton>
-					</ListItemContentTitle>
-					<ListItemContentSubtitle
-						style={precompileStyles({
-							display: "flex",
-							flexWrap: "wrap",
-							gap: ".25rem",
-						})}
-					>
-						<Skeleton className="max-w-[21.666666666666668ch]">
-							{entry ? <MediaListItemSubtitle entry={entry} /> : null}
-						</Skeleton>
-					</ListItemContentSubtitle>
-				</ListItemContent>
-				{children}
-			</ListItem>
+					<Skeleton className="max-w-[21.666666666666668ch]">
+						{entry ? <MediaListItemSubtitle entry={entry} /> : null}
+					</Skeleton>
+				</ListItemContentSubtitle>
+			</ListItemContent>
+			{children}
+		</ListItem>
 	)
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ catalogs:
       specifier: 10.1.0
       version: 10.1.0
     eslint-plugin-oxlint:
-      specifier: 1.56.0
-      version: 1.56.0
+      specifier: 1.63.0
+      version: 1.63.0
     eslint-plugin-perfectionist:
       specifier: 5.7.0
       version: 5.7.0
@@ -763,7 +763,7 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       eslint-plugin-oxlint:
         specifier: 'catalog:'
-        version: 1.56.0
+        version: 1.63.0(oxlint@1.63.0(oxlint-tsgolint@0.22.1))
       eslint-plugin-perfectionist:
         specifier: 'catalog:'
         version: 5.7.0(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.3)
@@ -790,7 +790,7 @@ importers:
         version: link:../eslint-plugin-jsx
       eslint-plugin-oxlint:
         specifier: 'catalog:'
-        version: 1.56.0
+        version: 1.63.0(oxlint@1.63.0(oxlint-tsgolint@0.22.1))
       eslint-plugin-react:
         specifier: 'catalog:'
         version: 7.37.5(eslint@10.1.0(jiti@2.6.1))
@@ -4949,8 +4949,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-oxlint@1.56.0:
-    resolution: {integrity: sha512-s47/OjE4cfQ+CD4eA38g+5axvwuyswY5H6acCdVGIvowYuLVJ6zrR7N260XfVVLRuyjjPO9L77qNYwSbmRNyuw==}
+  eslint-plugin-oxlint@1.63.0:
+    resolution: {integrity: sha512-eqZ8pLk4Lz2HKqXC/BLceVzYP/cO0OHOAUBlLOau3Vk/I39mYbAFcmlAqJusTqEn2tgH/Nh/JUGKbCwf8k4DMA==}
+    peerDependencies:
+      oxlint: ~1.63.0
 
   eslint-plugin-perfectionist@5.7.0:
     resolution: {integrity: sha512-WRHj7OZS/INutQ/gKN5C1ZGnMhkQ3oKZQAA2I7rl5yM8keBtSd9oj/qlJaHuwh5873FhMPqYlttcadF0YsTN7g==}
@@ -10305,7 +10307,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -10315,7 +10317,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/deep-eql@4.0.2': {}
 
@@ -10333,7 +10335,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/marked@0.3.0': {}
 
@@ -10341,7 +10343,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/node@24.12.2':
     dependencies:
@@ -10350,6 +10352,7 @@ snapshots:
   '@types/node@25.5.2':
     dependencies:
       undici-types: 7.18.2
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -10361,7 +10364,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -10386,28 +10389,28 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/statuses@2.0.6': {}
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/trusted-types@2.0.7':
     optional: true
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.3)':
@@ -10944,7 +10947,7 @@ snapshots:
 
   bun-types@1.3.13:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 24.12.2
 
   bundle-name@4.1.0:
     dependencies:
@@ -11495,9 +11498,10 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-oxlint@1.56.0:
+  eslint-plugin-oxlint@1.63.0(oxlint@1.63.0(oxlint-tsgolint@0.22.1)):
     dependencies:
       jsonc-parser: 3.3.1
+      oxlint: 1.63.0(oxlint-tsgolint@0.22.1)
 
   eslint-plugin-perfectionist@5.7.0(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
@@ -13928,7 +13932,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.18.2:
+    optional: true
 
   undici@7.24.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,7 @@ catalog:
   electron: 41.5.0
   electron-devtools-installer: 4.0.0
   eslint: 10.1.0
-  eslint-plugin-oxlint: 1.56.0
+  eslint-plugin-oxlint: 1.63.0
   eslint-plugin-perfectionist: 5.7.0
   eslint-plugin-pnpm: 1.6.0
   eslint-plugin-react: 7.37.5


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump eslint-plugin-oxlint from 1.56.0 to 1.63.0 in pnpm workspace and regenerate the lockfile.