### PR TITLE
Prefer flat e2e tests 

### DIFF
--- a/apps/web/tests/404.spec.ts
+++ b/apps/web/tests/404.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from "@playwright/test"
 import { test } from "./fixtures"
 
-test("showing not found", async ({ page, worker, isElectron: electron }) => {
-	test.skip(electron, "Electron doesn't support goto")
-
+test("showing not found", async ({ newPage, isElectron }) => {
+	test.skip(isElectron, "Electron doesn't support goto")
+	await using page = await newPage()
 	await page.goto("/foo/bar/baz")
 
 	await expect(page.getByText("Not found")).toBeVisible()

--- a/apps/web/tests/fixtures.ts
+++ b/apps/web/tests/fixtures.ts
@@ -1,5 +1,5 @@
 import { defineNetworkFixture, type NetworkFixture } from "@msw/playwright"
-import base, { type ElectronApplication } from "@playwright/test"
+import base, { type ElectronApplication, type Page } from "@playwright/test"
 
 import { addMocksToSchema } from "@graphql-tools/mock"
 import { _electron } from "@playwright/test"
@@ -46,6 +46,7 @@ export interface Fixtures extends Options {
 	handlers: AnyHandler[]
 	worker: NetworkFixture
 	electron: ElectronApplication | null
+	newPage: () => Promise<Page>
 }
 
 export const test = base.extend<Fixtures>({
@@ -95,16 +96,20 @@ export const test = base.extend<Fixtures>({
 		await provide(electron.context())
 	},
 
-	async page({ context, electron }, provide) {
-		if (electron == null) {
-			await using page = await context.newPage()
-			await page.goto("/")
-			await provide(page)
-			return
-		}
+	page() {
+		throw new Error("Use `newPage` instead")
+	},
 
-		const page = await electron.firstWindow()
-		await provide(page)
-		await page.close()
+	async newPage({ context, electron }, provide) {
+		await provide(async () => {
+			if (electron == null) {
+				const page = await context.newPage()
+				await page.goto("/")
+				return page
+			}
+
+			const page = await electron.firstWindow()
+			return page
+		})
 	},
 })

--- a/apps/web/tests/search.spec.ts
+++ b/apps/web/tests/search.spec.ts
@@ -62,9 +62,12 @@ const handlers = [
 
 test.fixme(true, "fix main page")
 
-test("when search, ArrowDown should change focus", async ({ page, worker }) => {
+test("when search, ArrowDown should change focus", async ({
+	newPage,
+	worker,
+}) => {
 	worker.use(...handlers)
-
+	await using page = await newPage()
 	await expect(page.getByTestId("hydrated")).toBeVisible()
 	await page.keyboard.press("Control+k")
 	const searchPage = SearchPage.new(page)
@@ -76,9 +79,9 @@ test("when search, ArrowDown should change focus", async ({ page, worker }) => {
 	await expect(searchPage.options.nth(1).and(searchPage.active)).toBeVisible()
 })
 
-test("search", async ({ page, worker }) => {
+test("search", async ({ newPage, worker }) => {
 	worker.use(...handlers)
-
+	await using page = await newPage()
 	await expect(page.getByTestId("hydrated")).toBeVisible()
 	await page.keyboard.press("Control+k")
 	const searchPage = SearchPage.new(page)

--- a/apps/web/tests/typelist.spec.ts
+++ b/apps/web/tests/typelist.spec.ts
@@ -42,95 +42,99 @@ class UserPage {
 }
 
 const Viewer = { id: 1, name: "User" }
+const AddToListMutationSuccess = graphql.mutation<
+	AddToListMutation$rawResponse,
+	AddToListMutation$variables
+>("AddToListMutation", ({ variables }) =>
+	HttpResponse.json({
+		data: {
+			SaveMediaListEntry: {
+				__typename: "MediaList",
+				status: variables.status,
+				id: variables.mediaId,
+				completedAt: null,
+				private: variables.private,
+				progress: 0,
+				score: 2,
+				startedAt: { day: 1, month: 2, year: 3 },
+				media: {
+					id: variables.mediaId,
+					title: { userPreferred: "Contained media title" },
+					type: "MANGA",
+					status: "FINISHED",
+					relations: {
+						edges: [
+							{
+								id: 200,
+								relationType: "COMPILATION",
+								node: {
+									id: 1,
+									title: { userPreferred: "Media title" },
+									coverImage: { color: null, large: null, medium: null },
+								},
+							},
+						],
+					},
+					episodes: null,
+					coverImage: { color: null, large: null, medium: null },
+					chapters: 1,
+				},
+			},
+		},
+	})
+)
+
+const SyncMediaMutationSuccess = graphql.mutation<
+	SyncMediaMutation$rawResponse,
+	SyncMediaMutation$variables
+>("SyncMediaMutation", ({ variables }) =>
+	HttpResponse.json({
+		data: {
+			SaveMediaListEntry: {
+				__typename: "MediaList",
+				status: variables.status,
+				id: variables.mediaId,
+				completedAt: variables.completedAt && {
+					day: variables.completedAt.day,
+					month: variables.completedAt.month,
+					year: variables.completedAt.year,
+				},
+				private: variables.private,
+				progress: 1,
+				score: 2,
+				startedAt: variables.startedAt && {
+					day: variables.startedAt.day,
+					month: variables.startedAt.month,
+					year: variables.startedAt.year,
+				},
+				media: {
+					id: variables.mediaId,
+					title: { userPreferred: "Contained media title" },
+					type: "MANGA",
+					status: "FINISHED",
+					relations: {
+						edges: [
+							{
+								id: 200,
+								relationType: "COMPILATION",
+								node: {
+									id: 1,
+									title: { userPreferred: "Media title" },
+									coverImage: { color: null, large: null, medium: null },
+								},
+							},
+						],
+					},
+					episodes: null,
+					coverImage: { color: null, large: null, medium: null },
+					chapters: 1,
+				},
+			},
+		},
+	})
+)
+
 const handlers = [
-	graphql.mutation<AddToListMutation$rawResponse, AddToListMutation$variables>(
-		"AddToListMutation",
-		({ variables }) =>
-			HttpResponse.json({
-				data: {
-					SaveMediaListEntry: {
-						__typename: "MediaList",
-						status: variables.status,
-						id: variables.mediaId,
-						completedAt: null,
-						private: variables.private,
-						progress: 0,
-						score: 2,
-						startedAt: { day: 1, month: 2, year: 3 },
-						media: {
-							id: variables.mediaId,
-							title: { userPreferred: "Contained media title" },
-							type: "MANGA",
-							status: "FINISHED",
-							relations: {
-								edges: [
-									{
-										id: 200,
-										relationType: "COMPILATION",
-										node: {
-											id: 1,
-											title: { userPreferred: "Media title" },
-											coverImage: { color: null, large: null, medium: null },
-										},
-									},
-								],
-							},
-							episodes: null,
-							coverImage: { color: null, large: null, medium: null },
-							chapters: 1,
-						},
-					},
-				},
-			})
-	),
-	graphql.mutation<SyncMediaMutation$rawResponse, SyncMediaMutation$variables>(
-		"SyncMediaMutation",
-		({ variables }) =>
-			HttpResponse.json({
-				data: {
-					SaveMediaListEntry: {
-						__typename: "MediaList",
-						status: variables.status,
-						id: variables.mediaId,
-						completedAt: variables.completedAt && {
-							day: variables.completedAt.day,
-							month: variables.completedAt.month,
-							year: variables.completedAt.year,
-						},
-						private: variables.private,
-						progress: 1,
-						score: 2,
-						startedAt: variables.startedAt && {
-							day: variables.startedAt.day,
-							month: variables.startedAt.month,
-							year: variables.startedAt.year,
-						},
-						media: {
-							id: variables.mediaId,
-							title: { userPreferred: "Contained media title" },
-							type: "MANGA",
-							status: "FINISHED",
-							relations: {
-								edges: [
-									{
-										id: 200,
-										relationType: "COMPILATION",
-										node: {
-											id: 1,
-											title: { userPreferred: "Media title" },
-											coverImage: { color: null, large: null, medium: null },
-										},
-									},
-								],
-							},
-							episodes: null,
-							coverImage: { color: null, large: null, medium: null },
-							chapters: 1,
-						},
-					},
-				},
-			})
-	),
 	graphql.query<
 		routeNavUserListEntriesQuery$rawResponse,
 		routeNavUserListEntriesQuery$variables
@@ -207,53 +211,70 @@ const handlers = [
 	SuccessHandler,
 ]
 
-const cookies = [
-	{
-		name: `anilist-token`,
-		value: invariant(
-			type("object.json.stringify")(
-				invariant(Token({ token: "", viewer: Viewer }))
-			)
-		),
-		sameSite: "Lax",
-		expires: Date.now() / 1000 + 8 * 7 * 24 * 60 * 60, // 8 weeks
-		// node doesn't support Temporal
-		// Temporal.Now.instant().add({ weeks: 8 }).epochMilliseconds / 1000,
-		path: "/",
-		domain: "localhost",
-	},
-] satisfies Parameters<BrowserContext["addCookies"]>[0]
+function login(context: BrowserContext) {
+	const cookies = [
+		{
+			name: `anilist-token`,
+			value: invariant(
+				type("object.json.stringify")(
+					invariant(Token({ token: "", viewer: Viewer }))
+				)
+			),
+			sameSite: "Lax",
+			expires: Date.now() / 1000 + 8 * 7 * 24 * 60 * 60, // 8 weeks
+			// node doesn't support Temporal
+			// Temporal.Now.instant().add({ weeks: 8 }).epochMilliseconds / 1000,
+			path: "/",
+			domain: "localhost",
+		},
+	] satisfies Parameters<BrowserContext["addCookies"]>[0]
+
+	return context.addCookies(cookies)
+}
 
 // test.fixme(true, "fix main page")
 
-test.beforeEach(async ({ worker, context }) => {
+test("fullscreen anime list", async ({
+	newPage,
+	isMobile,
+	isElectron,
+	worker,
+	context,
+}) => {
+	test.skip(isMobile || isElectron)
 	worker.use(...handlers)
-	await context.addCookies(cookies)
+	await login(context)
+	await using page = await newPage()
+
+	const indexPage = await FeedPage.new(page)
+	// when
+	await indexPage.nav.animeList.click()
+	// then
+	await TypelistPage.new(page)
 })
 
-test.describe("fullscreen", () => {
-	test("anime list", async ({ page, isMobile, isElectron }) => {
-		test.skip(isMobile || isElectron)
-
-		const indexPage = await FeedPage.new(page)
-		// when
-		await indexPage.nav.animeList.click()
-		// then
-		await TypelistPage.new(page)
-	})
-
-	test("manga list", async ({ page, isMobile, isElectron }) => {
-		test.skip(isMobile || isElectron)
-
-		const indexPage = await FeedPage.new(page)
-		// when
-		await indexPage.nav.mangaList.click()
-		// then
-		await TypelistPage.new(page)
-	})
+test("fullscreen manga list", async ({
+	worker,
+	context,
+	newPage,
+	isMobile,
+	isElectron,
+}) => {
+	test.skip(isMobile || isElectron)
+	worker.use(...handlers)
+	await login(context)
+	await using page = await newPage()
+	const indexPage = await FeedPage.new(page)
+	// when
+	await indexPage.nav.mangaList.click()
+	// then
+	await TypelistPage.new(page)
 })
 
-test("anime list", async ({ page }) => {
+test("anime list", async ({ worker, newPage, context }) => {
+	worker.use(...handlers)
+	await login(context)
+	await using page = await newPage()
 	const indexPage = await FeedPage.new(page)
 	await indexPage.nav.profile.click()
 	const userpage = UserPage.new(page)
@@ -263,7 +284,10 @@ test("anime list", async ({ page }) => {
 	await TypelistPage.new(page)
 })
 
-test("manga list", async ({ page }) => {
+test("manga list", async ({ worker, context, newPage }) => {
+	worker.use(...handlers)
+	await login(context)
+	await using page = await newPage()
 	const indexPage = await FeedPage.new(page)
 	await indexPage.nav.profile.click()
 	const userpage = UserPage.new(page)
@@ -273,7 +297,10 @@ test("manga list", async ({ page }) => {
 	await TypelistPage.new(page)
 })
 
-test("add to list", async ({ page }) => {
+test("add to list", async ({ worker, newPage, context }) => {
+	worker.use(AddToListMutationSuccess, ...handlers)
+	await login(context)
+	await using page = await newPage()
 	const indexPage = await FeedPage.new(page)
 	await indexPage.nav.profile.click()
 	const userpage = UserPage.new(page)
@@ -286,7 +313,10 @@ test("add to list", async ({ page }) => {
 	await expect(containedEntry.progress).toHaveText(/0/)
 	await expect(containedEntry.privateBadge).toBeAttached()
 })
-test("sync media", async ({ page }) => {
+test("sync media", async ({ worker, newPage, context }) => {
+	worker.use(SyncMediaMutationSuccess, ...handlers)
+	await login(context)
+	await using page = await newPage()
 	const indexPage = await FeedPage.new(page)
 	await indexPage.nav.profile.click()
 	const userpage = UserPage.new(page)


### PR DESCRIPTION
## Summary by Sourcery

Refactor Playwright e2e tests to use a reusable page factory and explicit login per test while flattening test structure.

Enhancements:
- Extract GraphQL mutation handlers into reusable `AddToListMutationSuccess` and `SyncMediaMutationSuccess` fixtures for tests.
- Introduce a shared `login` helper to set authentication cookies in e2e tests.
- Replace the direct `page` fixture with a `newPage` factory in the test fixtures to standardize page creation for web and Electron environments.
- Update typelist and search tests to use the new `newPage` fixture and flattened, top-level tests instead of nested suites and `beforeEach` setup.