### PR TITLE
🔧 Remove pnpm cache from Node setup

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -70,7 +69,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -98,7 +96,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -134,7 +131,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -94,7 +93,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -118,7 +116,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -142,7 +139,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -164,7 +160,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: package.json
-          cache: "pnpm"
 
       - name: Install dependencies 📦
         run: pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Stop using pnpm cache in actions/setup-node across all test, deploy, formatting, screenshot update, Chromatic, and CodSpeed workflows.