### PR TITLE
🔧 refactor: extract GitHub context to env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,9 +77,10 @@ jobs:
         run: pnpm exec turbo --filter=@anitrove/web build
 
       - name: Deploy
-        run: pnpm exec wrangler pages deploy --branch=${{ github.head_ref || github.ref_name  }}
+        run: pnpm exec wrangler pages deploy --branch=${BRANCH}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          BRANCH: ${{ github.head_ref || github.ref_name  }}
 
   stryker:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -86,15 +86,18 @@ jobs:
 
       - name: Push changes
         if: steps.check_changes.outputs.changes == 'true'
-        run: git push origin ${{ github.ref_name }}
-
+        run: git push origin ${REF_NAME}
+        env:
+          REF_NAME: ${{ github.ref_name }}
       # pretty summary for humans
       - name: Summary
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${{ steps.check_changes.outputs.changes }}" == "true" ]]; then
             echo "### 📸 Visual Regression Screenshots Updated" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Successfully updated **${{ steps.check_changes.outputs.changed_count }}** screenshot(s) on \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "Successfully updated **${{ steps.check_changes.outputs.changed_count }}** screenshot(s) on \`${REF_NAME}\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "#### Changed Files:" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary by Sourcery

Refactor GitHub Actions workflows to read branch and ref name from environment variables instead of inline GitHub context expressions.

CI:
- Update screenshot update workflow to use environment variables for the current ref name in git push and summary output.
- Adjust deployment workflow to pass the deployment branch via an environment variable for the wrangler pages deploy command.