### PR TITLE
🔧 Add master branch to zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - renovate/**
+      - master
   pull_request:
   merge_group:
   workflow_dispatch:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Trigger the zizmor workflow on pushes to the master branch.