### PR TITLE
🔧 Enable vitest/no-alias-methods rule

### DIFF
--- a/packages/oxlint-config/oxlintrc.json
+++ b/packages/oxlint-config/oxlintrc.json
@@ -14,6 +14,7 @@
 	],
 	"env": { "node": true, "browser": true },
 	"rules": {
+		"vitest/no-alias-methods": "error",
 		"eslint/no-unused-expressions": "error",
 		"eslint/eqeqeq": ["error", "always", { "null": "never" }],
 		"eslint/prefer-template": "error",


### PR DESCRIPTION
## Summary by Sourcery

Enable and configure the vitest/no-alias-methods lint rule in the shared oxlint configuration.