### PR TITLE
🎨 Add dynamic CSS variables support to styles

### DIFF
--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -21,18 +21,8 @@ declare module "react" {
 function Button({ size, shape, color, ...props }: ButtonProps) {
 	return (
 		<Box
-			render={
-				<button
-					type="button"
-					{...props}
-					style={{
-						"--size": size && `var(--size-${size})`,
-						"--color": color && `var(--color-${color})`,
-						"--shape": shape && `var(--shape-${shape})`,
-					}}
-				></button>
-			}
-			style={button.style}
+			render={<button type="button" {...props}></button>}
+			style={button({ size, color, shape })}
 		></Box>
 	)
 }

--- a/apps/web/app/components/Layout.tsx
+++ b/apps/web/app/components/Layout.tsx
@@ -2,11 +2,11 @@ import { createContext, use, type ComponentProps, type ReactNode } from "react"
 
 import * as design from "@anitrove/design"
 import {
-	cva,
-	defineCva,
-	mergeStyles,
-	type CvaProps,
-	type PreCompiledStyles,
+    cva,
+    defineCva,
+    mergeStyles,
+    type CvaProps,
+    type OutStyles,
 } from "@anitrove/unstyled"
 import { Box } from "@anitrove/unstyled/box"
 const layoutDefinition = defineCva({
@@ -62,7 +62,7 @@ interface LayoutProps
 	extends
 		CvaProps<typeof layoutDefinition>,
 		Omit<ComponentProps<"div">, "className" | "style"> {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function Layout({ style, navigation, ...props }: LayoutProps) {
@@ -84,7 +84,7 @@ interface LayoutBodyProps extends Omit<
 	ComponentProps<"main">,
 	"className" | "style"
 > {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function LayoutBody({ style, ...props }: LayoutBodyProps): ReactNode {
@@ -120,7 +120,7 @@ interface LayoutPaneProps
 	extends
 		CvaProps<typeof paneDefinition>,
 		Omit<Ariakit.RoleProps<"section">, "className" | "style"> {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function LayoutPane({

--- a/apps/web/app/components/Layout.tsx
+++ b/apps/web/app/components/Layout.tsx
@@ -2,11 +2,11 @@ import { createContext, use, type ComponentProps, type ReactNode } from "react"
 
 import * as design from "@anitrove/design"
 import {
-    cva,
-    defineCva,
-    mergeStyles,
-    type CvaProps,
-    type OutStyles,
+	cva,
+	defineCva,
+	mergeStyles,
+	type CvaProps,
+	type OutStyles,
 } from "@anitrove/unstyled"
 import { Box } from "@anitrove/unstyled/box"
 const layoutDefinition = defineCva({

--- a/apps/web/app/components/List.tsx
+++ b/apps/web/app/components/List.tsx
@@ -2,11 +2,11 @@ import { createContext, use, type ReactNode } from "react"
 
 import * as design from "@anitrove/design"
 import {
-    cva,
-    defineCva,
-    mergeStyles,
-    type CvaProps,
-    type OutStyles,
+	cva,
+	defineCva,
+	mergeStyles,
+	type CvaProps,
+	type OutStyles,
 } from "@anitrove/unstyled"
 import { Box } from "@anitrove/unstyled/box"
 import * as Ariakit from "@ariakit/react"

--- a/apps/web/app/components/List.tsx
+++ b/apps/web/app/components/List.tsx
@@ -2,11 +2,11 @@ import { createContext, use, type ReactNode } from "react"
 
 import * as design from "@anitrove/design"
 import {
-	cva,
-	defineCva,
-	mergeStyles,
-	type CvaProps,
-	type PreCompiledStyles,
+    cva,
+    defineCva,
+    mergeStyles,
+    type CvaProps,
+    type OutStyles,
 } from "@anitrove/unstyled"
 import { Box } from "@anitrove/unstyled/box"
 import * as Ariakit from "@ariakit/react"
@@ -52,7 +52,7 @@ interface ListItemProps extends Omit<
 	Ariakit.RoleProps<"li">,
 	"className" | "style"
 > {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function ListItem({ style, ...props }: ListItemProps) {
@@ -106,7 +106,7 @@ interface ListItemContentProps extends Omit<
 	Ariakit.RoleProps,
 	"className" | "style"
 > {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function ListItemContent({
@@ -147,7 +147,7 @@ interface ListItemContentSubtitleProps extends Omit<
 	Ariakit.RoleProps,
 	"className" | "style"
 > {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function ListItemContentSubtitle({
@@ -185,7 +185,7 @@ interface ListItemImgProps extends Omit<
 	Ariakit.RoleProps,
 	"className" | "style"
 > {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function ListItemImg({ style, ...props }: ListItemImgProps): ReactNode {
@@ -257,7 +257,7 @@ interface ListProps
 	extends
 		CvaProps<typeof listDefinition>,
 		Omit<Ariakit.RoleProps<"ul">, "className" | "style"> {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 const listDefinition = defineCva({

--- a/apps/web/app/lib/entry/MediaListItem.tsx
+++ b/apps/web/app/lib/entry/MediaListItem.tsx
@@ -5,11 +5,11 @@ import ReactRelay from "react-relay"
 
 import type { ReactNode } from "react"
 import {
-    ListItem,
-    ListItemContent,
-    ListItemContentSubtitle,
-    ListItemContentTitle,
-    ListItemImg,
+	ListItem,
+	ListItemContent,
+	ListItemContentSubtitle,
+	ListItemContentTitle,
+	ListItemImg,
 } from "~/components/List"
 
 import MaterialSymbolsStarOutline from "~icons/material-symbols/star-outline"
@@ -22,9 +22,9 @@ import { formatWatch } from "./ToWatch"
 import { A } from "@anitrove/a"
 import { media, utilities } from "@anitrove/design"
 import {
-    mergeStyles,
-    precompileStyles,
-    type OutStyles,
+	mergeStyles,
+	precompileStyles,
+	type OutStyles,
 } from "@anitrove/unstyled"
 import { CompositeItem, CompositeRow } from "@ariakit/react"
 import type { MediaListItem_entry$key } from "~/gql/MediaListItem_entry.graphql"
@@ -33,8 +33,8 @@ import type { MediaListItem_media$key } from "~/gql/MediaListItem_media.graphql"
 import { Box } from "@anitrove/unstyled/box"
 import { Badge } from "~/components/Badge"
 import type {
-    MediaListItemSubtitle_entry$key,
-    MediaType,
+	MediaListItemSubtitle_entry$key,
+	MediaType,
 } from "~/gql/MediaListItemSubtitle_entry.graphql"
 import * as Predicate from "~/lib/Predicate"
 import { useFragment } from "../Network"

--- a/apps/web/app/lib/entry/MediaListItem.tsx
+++ b/apps/web/app/lib/entry/MediaListItem.tsx
@@ -5,11 +5,11 @@ import ReactRelay from "react-relay"
 
 import type { ReactNode } from "react"
 import {
-	ListItem,
-	ListItemContent,
-	ListItemContentSubtitle,
-	ListItemContentTitle,
-	ListItemImg,
+    ListItem,
+    ListItemContent,
+    ListItemContentSubtitle,
+    ListItemContentTitle,
+    ListItemImg,
 } from "~/components/List"
 
 import MaterialSymbolsStarOutline from "~icons/material-symbols/star-outline"
@@ -22,9 +22,9 @@ import { formatWatch } from "./ToWatch"
 import { A } from "@anitrove/a"
 import { media, utilities } from "@anitrove/design"
 import {
-	mergeStyles,
-	precompileStyles,
-	type PreCompiledStyles,
+    mergeStyles,
+    precompileStyles,
+    type OutStyles,
 } from "@anitrove/unstyled"
 import { CompositeItem, CompositeRow } from "@ariakit/react"
 import type { MediaListItem_entry$key } from "~/gql/MediaListItem_entry.graphql"
@@ -33,8 +33,8 @@ import type { MediaListItem_media$key } from "~/gql/MediaListItem_media.graphql"
 import { Box } from "@anitrove/unstyled/box"
 import { Badge } from "~/components/Badge"
 import type {
-	MediaListItemSubtitle_entry$key,
-	MediaType,
+    MediaListItemSubtitle_entry$key,
+    MediaType,
 } from "~/gql/MediaListItemSubtitle_entry.graphql"
 import * as Predicate from "~/lib/Predicate"
 import { useFragment } from "../Network"
@@ -78,7 +78,7 @@ export function MediaListItem({
 	entry: MediaListItem_entry$key | null | undefined
 	media: MediaListItem_media$key
 
-	style?: PreCompiledStyles
+	style?: OutStyles
 }): ReactNode {
 	const entry = useFragment(MediaListItem_entry, entryKey)
 	const data = useFragment(MediaListItem_media, mediaKey)

--- a/apps/web/app/lib/theme/index.tsx
+++ b/apps/web/app/lib/theme/index.tsx
@@ -1,12 +1,12 @@
 import {
-    argbFromHex,
-    blueFromArgb,
-    DynamicColor,
-    greenFromArgb,
-    Hct,
-    MaterialDynamicColors,
-    redFromArgb,
-    SchemeTonalSpot,
+	argbFromHex,
+	blueFromArgb,
+	DynamicColor,
+	greenFromArgb,
+	Hct,
+	MaterialDynamicColors,
+	redFromArgb,
+	SchemeTonalSpot,
 } from "@material/material-color-utilities"
 import type { CSSProperties } from "react"
 

--- a/apps/web/app/lib/theme/index.tsx
+++ b/apps/web/app/lib/theme/index.tsx
@@ -1,19 +1,19 @@
 import {
-	argbFromHex,
-	blueFromArgb,
-	DynamicColor,
-	greenFromArgb,
-	Hct,
-	MaterialDynamicColors,
-	redFromArgb,
-	SchemeTonalSpot,
+    argbFromHex,
+    blueFromArgb,
+    DynamicColor,
+    greenFromArgb,
+    Hct,
+    MaterialDynamicColors,
+    redFromArgb,
+    SchemeTonalSpot,
 } from "@material/material-color-utilities"
 import type { CSSProperties } from "react"
 
 import colors from "@anitrove/design/colors"
-import { precompileStyles, type PreCompiledStyles } from "@anitrove/unstyled"
+import { precompileStyles, type OutStyles } from "@anitrove/unstyled"
 
-export type Theme = PreCompiledStyles
+export type Theme = OutStyles
 
 const {
 	contentAccentToneDelta: _contentAccentToneDelta,

--- a/packages/design/src/design-tokens.ts
+++ b/packages/design/src/design-tokens.ts
@@ -54,7 +54,15 @@ export const typescale = Object.fromEntries(
 			},
 		]
 	)
-) as unknown as Record<keyof typeof fonts, RawStyles>
+) as unknown as Record<
+	keyof typeof fonts,
+	{
+		fontSize: string
+		fontWeight: number
+		letterSpacing: string
+		lineHeight: number
+	}
+>
 
 export const transitions = {
 	spatial: {

--- a/packages/design/src/design-utilities.ts
+++ b/packages/design/src/design-utilities.ts
@@ -4,6 +4,20 @@ import type { RawStyles } from "@anitrove/unstyled"
 import type { Property } from "csstype"
 import colors from "./design-colors"
 
+import * as tokens from "./design-tokens"
+
+export function typescale(scale: Value<keyof typeof tokens.typescale>) {
+	return {
+		fontSize: mapValue(scale, (scale) => tokens.typescale[scale].fontSize),
+		fontWeight: mapValue(scale, (scale) => tokens.typescale[scale].fontWeight),
+		letterSpacing: mapValue(
+			scale,
+			(scale) => tokens.typescale[scale].letterSpacing
+		),
+		lineHeight: mapValue(scale, (scale) => tokens.typescale[scale].lineHeight),
+	}
+}
+
 export function contrast(value: string): Record<`--${string}`, string>
 export function contrast(
 	value: Value<string>

--- a/packages/m3-react/src/m3-react-button.bench.ts
+++ b/packages/m3-react/src/m3-react-button.bench.ts
@@ -1,7 +1,10 @@
-import { cva } from "@anitrove/unstyled"
-import { bench, describe } from "vitest"
-import { buttonDefinition } from "./m3-react-button"
+import { bench } from "vitest"
+import { button, createButton } from "./m3-react-button"
 
 bench("cva", () => {
-	void cva(buttonDefinition)
+	void createButton()
+})
+
+bench("cva", () => {
+	button({})
 })

--- a/packages/m3-react/src/m3-react-button.bench.ts
+++ b/packages/m3-react/src/m3-react-button.bench.ts
@@ -5,6 +5,6 @@ bench("cva", () => {
 	void createButton()
 })
 
-bench("cva", () => {
-	button({})
+bench("apply vars", () => {
+	void button({})
 })

--- a/packages/m3-react/src/m3-react-button.spec.ts
+++ b/packages/m3-react/src/m3-react-button.spec.ts
@@ -1,13 +1,13 @@
 import { print } from "@anitrove/unstyled"
-import { describe, expect, it } from "vitest"
+import { expect, it } from "vitest"
 import { button } from "./m3-react-button"
 
 it("css size", () => {
-	expect(print(button.style).length).toMatchInlineSnapshot(`3581`)
+	expect(print(button({})).length).toMatchInlineSnapshot(`3581`)
 })
 
 it("print", () => {
-	expect(print(button.style)).toMatchInlineSnapshot(`
+	expect(print(button({}))).toMatchInlineSnapshot(`
 			"{
 			  display: inline-flex;
 			  align-items: center;
@@ -71,4 +71,14 @@ it("print", () => {
 			  }
 			}"
 		`)
+})
+
+it("vars", () => {
+	expect(button({}).dynamicVars).toMatchInlineSnapshot(`
+		{
+		  "--color": "filled",
+		  "--shape": "round",
+		  "--size": "sm",
+		}
+	`)
 })

--- a/packages/m3-react/src/m3-react-button.spec.ts
+++ b/packages/m3-react/src/m3-react-button.spec.ts
@@ -3,74 +3,219 @@ import { expect, it } from "vitest"
 import { button } from "./m3-react-button"
 
 it("css size", () => {
-	expect(print(button({})).length).toMatchInlineSnapshot(`3581`)
+	expect(print(button({})).length).toMatchInlineSnapshot(`4798`)
 })
 
 it("print", () => {
 	expect(print(button({}))).toMatchInlineSnapshot(`
-			"{
-			  display: inline-flex;
-			  align-items: center;
-			  justify-content: center;
-			  white-space: nowrap;
-			  text-box: trim-both cap alphabetic;
-			  font-size: var(--size-xs, 0.875rem) var(--size-sm, 0.875rem) var(--size-md, 1rem) var(--size-lg, 1.5rem) var(--size-xl, 2rem);
-			  font-weight: var(--size-xs, 500) var(--size-sm, 500) var(--size-md, 500) var(--size-lg, 400) var(--size-xl, 400);
-			  letter-spacing: var(--size-xs, 0.0071428571428571435rem) var(--size-sm, 0.0071428571428571435rem) var(--size-md, 0.009375rem) var(--size-lg, 0rem) var(--size-xl, 0rem);
-			  line-height: var(--size-xs, 1.4285714285714286) var(--size-sm, 1.4285714285714286) var(--size-md, 1.5) var(--size-lg, 1.3333333333333333) var(--size-xl, 1.25);
-			  background-image: linear-gradient(color-mix(in oklab, currentColor, transparent var(--state)), color-mix(in oklab, currentColor, transparent var(--state)));
-			  &:hover {
-			    --state: 92%;
-			  }
-			  &:focus-visible, &[data-focus-visible] {
-			    --state: 90%;
-			    &:hover {
-			      --state: 90%;
-			    }
-			  }
-			  &:active, &[data-active] {
-			    --state: 90%;
-			  }
-			  &:disabled, &[aria-disabled="true"] {
-			    --state: 100%;
-			  }
-			  @media (prefers-reduced-motion: no-preference) {
-			    transition-property: border-radius;
-			  }
-			  transition-timing-function: cubic-bezier(0.42, 1.67, 0.21, 0.9);
-			  transition-duration: 350ms;
-			  --color: var(--color-filled);
-			  --size: var(--size-sm);
-			  --shape: var(--shape-round);
-			  --color-outlined: var(--color,);
-			  --color-elevated: var(--color,);
-			  --color-filled: var(--color,);
-			  --color-text: var(--color,);
-			  --color-tonal: var(--color,);
-			  ring-color: var(--color-outlined, rgb(var(--outline)));
-			  &[aria-disabled="true"] {
-			    ring-color: var(--color-outlined, rgb(var(--outline-variant) / 12%));
-			  }
-			  ring-inset: var(--color-outlined, inset);
-			  ring: var(--size-lg, 2) var(--size-xl, 3);
-			  color: var(--color-outlined, rgb(var(--on-surface-variant))) var(--color-elevated, rgb(var(--primary))) var(--color-filled, rgb(var(--on-primary))) var(--color-text, rgb(var(--primary))) var(--color-tonal, rgb(var(--on-secondary-container)));
-			  background-color: var(--color-elevated, rgb(var(--surface-container-low))) var(--color-filled, rgb(var(--primary))) var(--color-tonal, rgb(var(--secondary-container)));
-			  --size-xs: var(--size,);
-			  --size-sm: var(--size,);
-			  --size-md: var(--size,);
-			  --size-lg: var(--size,);
-			  --size-xl: var(--size,);
-			  height: var(--size-xs, 2rem) var(--size-sm, 2.5rem) var(--size-md, 3.5rem) var(--size-lg, 6rem) var(--size-xl, 8.5rem);
-			  gap: var(--size-xs, .25rem) var(--size-sm, .5rem) var(--size-md, .5rem) var(--size-lg, .75rem) var(--size-xl, 1rem);
-			  padding-inline: var(--size-xs, .75rem) var(--size-sm, 1rem) var(--size-md, 1.5rem) var(--size-lg, 3rem) var(--size-xl, 4rem);
-			  --shape-round: var(--shape,);
-			  --shape-square: var(--shape,);
-			  border-radius: var(--size-xs, var(--shape-round, 1rem) var(--shape-square, .75rem)) var(--size-sm, var(--shape-round, 1.25rem) var(--shape-square, .75rem)) var(--size-md, var(--shape-round, 1.75rem) var(--shape-square, 1rem)) var(--size-lg, var(--shape-round, 3rem) var(--shape-square, 1.75rem)) var(--size-xl, var(--shape-round, 4.25rem) var(--shape-square, 1.75rem));
-			  &:active, &[data-active] {
-			    border-radius: var(--size-xs, var(--shape-round, .5rem) var(--shape-square, .5rem)) var(--size-sm, var(--shape-round, .5rem) var(--shape-square, .5rem)) var(--size-md, var(--shape-round, .75rem) var(--shape-square, .75rem)) var(--size-lg, var(--shape-round, 1rem) var(--shape-square, 1rem)) var(--size-xl, var(--shape-round, 1rem) var(--shape-square, 1rem));
-			  }
-			}"
-		`)
+		"{
+		  display: inline-flex;
+		  align-items: center;
+		  justify-content: center;
+		  white-space: nowrap;
+		  text-box: trim-both cap alphabetic;
+		  background-image: linear-gradient(color-mix(in oklab, currentColor, transparent var(--state)), color-mix(in oklab, currentColor, transparent var(--state)));
+		  &:hover {
+		    --state: 92%;
+		  }
+		  &:focus-visible, &[data-focus-visible] {
+		    --state: 90%;
+		    &:hover {
+		      --state: 90%;
+		    }
+		  }
+		  &:active, &[data-active] {
+		    --state: 90%;
+		  }
+		  &:disabled, &[aria-disabled="true"] {
+		    --state: 100%;
+		  }
+		  @media (prefers-reduced-motion: no-preference) {
+		    transition-property: border-radius;
+		  }
+		  transition-timing-function: cubic-bezier(0.42, 1.67, 0.21, 0.9);
+		  transition-duration: 350ms;
+		  @container style(--color: outlined) {
+		    ring-color: rgb(var(--outline));
+		    &[aria-disabled="true"] {
+		      ring-color: rgb(var(--outline-variant) / 12%);
+		    }
+		  }
+		  @container style(--color: outlined) {
+		    ring-inset: inset;
+		  }
+		  @container style(--color: outlined) {
+		    ring: 1;
+		  }
+		  @container style(--size: lg) {
+		    ring: 2;
+		  }
+		  @container style(--size: xl) {
+		    ring: 3;
+		  }
+		  @container style(--color: outlined) {
+		    color: rgb(var(--on-surface-variant));
+		  }
+		  @container style(--color: elevated) {
+		    color: rgb(var(--primary));
+		  }
+		  @container style(--color: filled) {
+		    color: rgb(var(--on-primary));
+		  }
+		  @container style(--color: text) {
+		    color: rgb(var(--primary));
+		  }
+		  @container style(--color: tonal) {
+		    color: rgb(var(--on-secondary-container));
+		  }
+		  @container style(--color: elevated) {
+		    background-color: rgb(var(--surface-container-low));
+		  }
+		  @container style(--color: filled) {
+		    background-color: rgb(var(--primary));
+		  }
+		  @container style(--color: tonal) {
+		    background-color: rgb(var(--secondary-container));
+		  }
+		  @container style(--size: xs) {
+		    height: 2rem;
+		  }
+		  @container style(--size: sm) {
+		    height: 2.5rem;
+		  }
+		  @container style(--size: md) {
+		    height: 3.5rem;
+		  }
+		  @container style(--size: lg) {
+		    height: 6rem;
+		  }
+		  @container style(--size: xl) {
+		    height: 8.5rem;
+		  }
+		  @container style(--size: xs) {
+		    gap: .25rem;
+		  }
+		  @container style(--size: sm) {
+		    gap: .5rem;
+		  }
+		  @container style(--size: md) {
+		    gap: .5rem;
+		  }
+		  @container style(--size: lg) {
+		    gap: .75rem;
+		  }
+		  @container style(--size: xl) {
+		    gap: 1rem;
+		  }
+		  @container style(--size: xs) {
+		    padding-inline: .75rem;
+		  }
+		  @container style(--size: sm) {
+		    padding-inline: 1rem;
+		  }
+		  @container style(--size: md) {
+		    padding-inline: 1.5rem;
+		  }
+		  @container style(--size: lg) {
+		    padding-inline: 3rem;
+		  }
+		  @container style(--size: xl) {
+		    padding-inline: 4rem;
+		  }
+		  font-size: 0.875rem;
+		  @container style(--size: md) {
+		    font-size: 1rem;
+		  }
+		  @container style(--size: lg) {
+		    font-size: 1.5rem;
+		  }
+		  @container style(--size: xl) {
+		    font-size: 2rem;
+		  }
+		  font-weight: 500;
+		  @container style(--size: md) {
+		    font-weight: 500;
+		  }
+		  @container style(--size: lg) {
+		    font-weight: 400;
+		  }
+		  @container style(--size: xl) {
+		    font-weight: 400;
+		  }
+		  letter-spacing: 0.0071428571428571435rem;
+		  @container style(--size: md) {
+		    letter-spacing: 0.009375rem;
+		  }
+		  @container style(--size: lg) {
+		    letter-spacing: 0rem;
+		  }
+		  @container style(--size: xl) {
+		    letter-spacing: 0rem;
+		  }
+		  line-height: 1.4285714285714286;
+		  @container style(--size: md) {
+		    line-height: 1.5;
+		  }
+		  @container style(--size: lg) {
+		    line-height: 1.3333333333333333;
+		  }
+		  @container style(--size: xl) {
+		    line-height: 1.25;
+		  }
+		  @container style(--shape: round) {
+		    @container style(--size: xs) {
+		      border-radius: 1rem;
+		      &:active, &[data-active] {
+		        border-radius: .5rem;
+		      }
+		    }
+		    @container style(--size: sm) {
+		      border-radius: 1.25rem;
+		      &:active, &[data-active] {
+		        border-radius: .5rem;
+		      }
+		    }
+		    @container style(--size: md) {
+		      border-radius: 1.75rem;
+		      &:active, &[data-active] {
+		        border-radius: .75rem;
+		      }
+		    }
+		    @container style(--size: lg) {
+		      border-radius: 3rem;
+		      &:active, &[data-active] {
+		        border-radius: 1rem;
+		      }
+		    }
+		    @container style(--size: xl) {
+		      border-radius: 4.25rem;
+		      &:active, &[data-active] {
+		        border-radius: 1rem;
+		      }
+		    }
+		  }
+		  @container style(--shape: square) {
+		    @container style(--size: xs) or style(--size: sm) {
+		      border-radius: .75rem;
+		      &:active, &[data-active] {
+		        border-radius: .5rem;
+		      }
+		    }
+		    @container style(--size: md) {
+		      border-radius: 1rem;
+		      &:active, &[data-active] {
+		        border-radius: .75rem;
+		      }
+		    }
+		    @container style(--size: lg) or style(--size: xl) {
+		      border-radius: 1.75rem;
+		      &:active, &[data-active] {
+		        border-radius: 1rem;
+		      }
+		    }
+		  }
+		}"
+	`)
 })
 
 it("vars", () => {

--- a/packages/m3-react/src/m3-react-button.tsx
+++ b/packages/m3-react/src/m3-react-button.tsx
@@ -3,22 +3,21 @@ import { media } from "@anitrove/design"
 import {
 	create,
 	is,
-	type PreCompiledStyles,
-	type RawStyles,
-	type Vars,
+	mergeStyles,
+	provide,
+	Var,
+	type OutStyles,
 } from "@anitrove/unstyled"
+
+const color = new Var<"elevated" | "filled" | "outlined" | "text" | "tonal">(
+	"--color"
+)
+const shape = new Var<"round" | "square">("--shape")
+const size = new Var<"lg" | "md" | "sm" | "xl" | "xs">("--size")
 
 export function createButton() {
 	return create({
-		button: ({
-			color,
-			shape,
-			size,
-		}: Vars<{
-			color: "elevated" | "filled" | "outlined" | "text" | "tonal"
-			shape: "round" | "square"
-			size: "lg" | "md" | "sm" | "xl" | "xs"
-		}>): RawStyles => ({
+		button: {
 			display: "inline-flex",
 			alignItems: "center",
 			justifyContent: "center",
@@ -112,20 +111,23 @@ export function createButton() {
 					},
 				},
 			},
-		}),
+		},
 	})
 }
 
 const styles = createButton()
 
-export function button({
-	color = "filled",
-	shape = "round",
-	size = "sm",
-}: {
-	color?: "elevated" | "filled" | "outlined" | "text" | "tonal"
-	shape?: "round" | "square"
-	size?: "lg" | "md" | "sm" | "xl" | "xs"
-} = {}): PreCompiledStyles {
-	return styles.button({ color, shape, size })
+export function button(
+	props: {
+		color?: "elevated" | "filled" | "outlined" | "text" | "tonal"
+		shape?: "round" | "square"
+		size?: "lg" | "md" | "sm" | "xl" | "xs"
+	} = {}
+): OutStyles {
+	return mergeStyles(
+		styles.button,
+		provide(color, props.color ?? "filled"),
+		provide(shape, props.shape ?? "round"),
+		provide(size, props.size ?? "sm")
+	)
 }

--- a/packages/m3-react/src/m3-react-button.tsx
+++ b/packages/m3-react/src/m3-react-button.tsx
@@ -1,136 +1,131 @@
 import * as design from "@anitrove/design"
 import { media } from "@anitrove/design"
-import { cva, defineCva } from "@anitrove/unstyled"
+import {
+	create,
+	is,
+	type PreCompiledStyles,
+	type RawStyles,
+	type Vars,
+} from "@anitrove/unstyled"
 
-export const buttonDefinition = defineCva({
-	base: {
-		display: "inline-flex",
-		alignItems: "center",
-		justifyContent: "center",
-		whiteSpace: "nowrap",
-		textBox: "trim-both cap alphabetic",
-		...design.tokens.typescale["label-lg"],
-		...design.state({
-			[media.hover]: "hover",
-			[media["focus-visible"]]: { base: "focus", [media.hover]: "focus" },
-			[media.active]: "pressed",
-			[media.disabled]: "none",
-		}),
-		transitionProperty: { [media.motionSafe]: "border-radius" },
-		...design.tokens.transitions.spatial.fast,
-	},
-	variants: {
-		color: {
-			outlined: {
-				ringColor: {
+export function createButton() {
+	return create({
+		button: ({
+			color,
+			shape,
+			size,
+		}: Vars<{
+			color: "elevated" | "filled" | "outlined" | "text" | "tonal"
+			shape: "round" | "square"
+			size: "lg" | "md" | "sm" | "xl" | "xs"
+		}>): RawStyles => ({
+			display: "inline-flex",
+			alignItems: "center",
+			justifyContent: "center",
+			whiteSpace: "nowrap",
+			textBox: "trim-both cap alphabetic",
+			...design.tokens.typescale["label-lg"],
+			...design.state({
+				[media.hover]: "hover",
+				[media["focus-visible"]]: { base: "focus", [media.hover]: "focus" },
+				[media.active]: "pressed",
+				[media.disabled]: "none",
+			}),
+			transitionProperty: { [media.motionSafe]: "border-radius" },
+			...design.tokens.transitions.spatial.fast,
+
+			ringColor: {
+				base: undefined,
+				[is(color, "outlined")]: {
 					base: design.tokens.colors.outline,
 					'&[aria-disabled="true"]': design.tokens.colors["outline-variant/12"],
 				},
-				ringInset: "inset",
-				ring: 1,
-				color: design.tokens.colors["on-surface-variant"],
 			},
-			elevated: {
-				backgroundColor: design.tokens.colors["surface-container-low"],
-				color: design.tokens.colors.primary,
+			ringInset: { base: undefined, [is(color, "outlined")]: "inset" },
+			ring: {
+				base: undefined,
+				[is(color, "outlined")]: 1,
+				[is(size, "lg")]: 2,
+				[is(size, "xl")]: 3,
 			},
-			filled: {
-				backgroundColor: design.tokens.colors.primary,
-				color: design.tokens.colors["on-primary"],
+			color: {
+				base: undefined,
+				[is(color, "outlined")]: design.tokens.colors["on-surface-variant"],
+				[is(color, "elevated")]: design.tokens.colors.primary,
+				[is(color, "filled")]: design.tokens.colors["on-primary"],
+				[is(color, "text")]: design.tokens.colors.primary,
+				[is(color, "tonal")]: design.tokens.colors["on-secondary-container"],
 			},
-			text: { color: design.tokens.colors.primary },
-			tonal: {
-				backgroundColor: design.tokens.colors["secondary-container"],
-				color: design.tokens.colors["on-secondary-container"],
+			backgroundColor: {
+				base: undefined,
+				[is(color, "elevated")]: design.tokens.colors["surface-container-low"],
+				[is(color, "filled")]: design.tokens.colors.primary,
+				[is(color, "tonal")]: design.tokens.colors["secondary-container"],
 			},
-		},
-		size: {
-			xs: {
-				height: "2rem",
-				gap: ".25rem",
-				...design.utilities.paddingX(".75rem"),
+			height: {
+				base: undefined,
+				[is(size, "xs")]: "2rem",
+				[is(size, "sm")]: "2.5rem",
+				[is(size, "md")]: "3.5rem",
+				[is(size, "lg")]: "6rem",
+				[is(size, "xl")]: "8.5rem",
 			},
-			sm: {
-				height: "2.5rem",
-				gap: ".5rem",
-				...design.utilities.paddingX("1rem"),
+			gap: {
+				base: undefined,
+				[is(size, "xs")]: ".25rem",
+				[is(size, "sm")]: ".5rem",
+				[is(size, "md")]: ".5rem",
+				[is(size, "lg")]: ".75rem",
+				[is(size, "xl")]: "1rem",
 			},
-			md: {
-				height: "3.5rem",
-				gap: ".5rem",
-				...design.utilities.paddingX("1.5rem"),
-				...design.tokens.typescale["title-md"],
-			},
-			lg: {
-				height: "6rem",
-				gap: ".75rem",
-				...design.utilities.paddingX("3rem"),
-				...design.tokens.typescale["headline-sm"],
-				ring: 2,
-			},
-			xl: {
-				height: "8.5rem",
-				gap: "1rem",
-				...design.utilities.paddingX("4rem"),
-				...design.tokens.typescale["headline-lg"],
-				ring: 3,
-			},
-		},
-		shape: { round: {}, square: {} },
-	},
-	compoundVariants: [
-		{
-			size: ["xs"],
-			shape: ["round"],
-			css: { borderRadius: { base: "1rem", [media.active]: ".5rem" } },
-		},
-		{
-			size: ["sm"],
-			shape: ["round"],
-			css: { borderRadius: { base: "1.25rem", [media.active]: ".5rem" } },
-		},
-		{
-			size: ["md"],
-			shape: ["round"],
-			css: { borderRadius: { base: "1.75rem", [media.active]: ".75rem" } },
-		},
-		{
-			size: ["lg"],
-			shape: ["round"],
-			css: { borderRadius: { base: "3rem", [media.active]: "1rem" } },
-		},
-		{
-			size: ["xl"],
-			shape: ["round"],
-			css: { borderRadius: { base: "4.25rem", [media.active]: "1rem" } },
-		},
-		{
-			size: ["xs", "sm"],
-			shape: ["square"],
-			css: { borderRadius: { base: ".75rem", [media.active]: ".5rem" } },
-		},
-		{
-			size: ["md"],
-			shape: ["square"],
-			css: {
-				borderRadius: {
-					base: design.tokens.borderRadius.lg,
-					[media.active]: ".75rem",
-				},
-			},
-		},
-		{
-			size: ["lg", "xl"],
-			shape: ["square"],
-			css: {
-				borderRadius: {
-					base: design.tokens.borderRadius.xl,
-					[media.active]: "1rem",
-				},
-			},
-		},
-	],
-	defaultVariants: { color: "filled", size: "sm", shape: "round" },
-})
+			...design.utilities.paddingX({
+				base: undefined,
+				[is(size, "xs")]: ".75rem",
+				[is(size, "sm")]: "1rem",
+				[is(size, "md")]: "1.5rem",
+				[is(size, "lg")]: "3rem",
+				[is(size, "xl")]: "4rem",
+			}),
+			...design.utilities.typescale({
+				[is(size, "md")]: "title-md",
+				[is(size, "lg")]: "headline-sm",
+				[is(size, "xl")]: "headline-lg",
+			}),
 
-export const button = cva(buttonDefinition)
+			borderRadius: {
+				[is(shape, "round")]: {
+					[is(size, "xs")]: { base: "1rem", [media.active]: ".5rem" },
+					[is(size, "sm")]: { base: "1.25rem", [media.active]: ".5rem" },
+					[is(size, "md")]: { base: "1.75rem", [media.active]: ".75rem" },
+					[is(size, "lg")]: { base: "3rem", [media.active]: "1rem" },
+					[is(size, "xl")]: { base: "4.25rem", [media.active]: "1rem" },
+				},
+				[is(shape, "square")]: {
+					[is(size, "xs", "sm")]: { base: ".75rem", [media.active]: ".5rem" },
+					[is(size, "md")]: {
+						base: design.tokens.borderRadius.lg,
+						[media.active]: ".75rem",
+					},
+					[is(size, "lg", "xl")]: {
+						base: design.tokens.borderRadius.xl,
+						[media.active]: "1rem",
+					},
+				},
+			},
+		}),
+	})
+}
+
+const styles = createButton()
+
+export function button({
+	color = "filled",
+	shape = "round",
+	size = "sm",
+}: {
+	color?: "elevated" | "filled" | "outlined" | "text" | "tonal"
+	shape?: "round" | "square"
+	size?: "lg" | "md" | "sm" | "xl" | "xs"
+} = {}): PreCompiledStyles {
+	return styles.button({ color, shape, size })
+}

--- a/packages/m3-react/src/m3-react-button.tsx
+++ b/packages/m3-react/src/m3-react-button.tsx
@@ -23,7 +23,6 @@ export function createButton() {
 			justifyContent: "center",
 			whiteSpace: "nowrap",
 			textBox: "trim-both cap alphabetic",
-			...design.tokens.typescale["label-lg"],
 			...design.state({
 				[media.hover]: "hover",
 				[media["focus-visible"]]: { base: "focus", [media.hover]: "focus" },
@@ -86,6 +85,7 @@ export function createButton() {
 				[is(size, "xl")]: "4rem",
 			}),
 			...design.utilities.typescale({
+				base: "label-lg",
 				[is(size, "md")]: "title-md",
 				[is(size, "lg")]: "headline-sm",
 				[is(size, "xl")]: "headline-lg",

--- a/packages/unstyled/src/unstyled-box.tsx
+++ b/packages/unstyled/src/unstyled-box.tsx
@@ -17,7 +17,7 @@ export function Box({ style, ...props }: BoxProps): ReactNode {
 		</>
 	)
 
-	return Object.keys(dynamicVars).length ? (
+	return Object.keys(dynamicVars).length !== 0 ? (
 		<div style={{ ...dynamicVars, display: "contents" }}>{children}</div>
 	) : (
 		children

--- a/packages/unstyled/src/unstyled-box.tsx
+++ b/packages/unstyled/src/unstyled-box.tsx
@@ -8,11 +8,18 @@ export interface BoxProps extends Omit<RoleProps, "className" | "style"> {
 }
 
 export function Box({ style, ...props }: BoxProps): ReactNode {
-	const [className, jsx] = useStyles(mergeStyles(style))
-	return (
+	const [className, jsx, dynamicVars] = useStyles(mergeStyles(style))
+
+	const children = (
 		<>
 			<Role {...props} className={className}></Role>
 			{jsx}
 		</>
+	)
+
+	return Object.keys(dynamicVars).length ? (
+		<div style={{ ...dynamicVars, display: "contents" }}>{children}</div>
+	) : (
+		children
 	)
 }

--- a/packages/unstyled/src/unstyled-box.tsx
+++ b/packages/unstyled/src/unstyled-box.tsx
@@ -1,10 +1,10 @@
 import { Role, type RoleProps } from "@ariakit/react"
 import type { ReactNode } from "react"
-import { mergeStyles, type PreCompiledStyles } from "./unstyled-print"
+import { mergeStyles, type OutStyles } from "./unstyled-print"
 import { useStyles } from "./unstyled-use-styles"
 
 export interface BoxProps extends Omit<RoleProps, "className" | "style"> {
-	style?: PreCompiledStyles
+	style?: OutStyles
 }
 
 export function Box({ style, ...props }: BoxProps): ReactNode {

--- a/packages/unstyled/src/unstyled-create.tsx
+++ b/packages/unstyled/src/unstyled-create.tsx
@@ -1,0 +1,19 @@
+import type { RawStyles } from "./unstyled-cva"
+import { precompileStyles, type PreCompiledStyles } from "./unstyled-print"
+import type { Vars } from "./unstyled-vars"
+
+export function create<
+	const Styles extends Record<string, ((vars: any) => RawStyles) | RawStyles>,
+>(
+	styles: Styles
+): {
+	[K in keyof Styles]: Styles[K] extends RawStyles
+		? PreCompiledStyles
+		: Styles[K] extends (vars: Vars<infer V>) => RawStyles
+			? (vars: V) => PreCompiledStyles
+			: never
+} {
+	return Object.fromEntries(
+		Object.entries(styles).map(([key, style]) => [key, precompileStyles(style)])
+	)
+}

--- a/packages/unstyled/src/unstyled-create.tsx
+++ b/packages/unstyled/src/unstyled-create.tsx
@@ -1,19 +1,13 @@
 import type { RawStyles } from "./unstyled-cva"
-import { precompileStyles, type PreCompiledStyles } from "./unstyled-print"
-import type { Vars } from "./unstyled-vars"
+import { precompileStyles, type OutStyles } from "./unstyled-print"
 
-export function create<
-	const Styles extends Record<string, ((vars: any) => RawStyles) | RawStyles>,
->(
+export function create<const Styles extends Record<string, RawStyles>>(
 	styles: Styles
-): {
-	[K in keyof Styles]: Styles[K] extends RawStyles
-		? PreCompiledStyles
-		: Styles[K] extends (vars: Vars<infer V>) => RawStyles
-			? (vars: V) => PreCompiledStyles
-			: never
-} {
+): { [K in keyof Styles]: OutStyles } {
 	return Object.fromEntries(
-		Object.entries(styles).map(([key, style]) => [key, precompileStyles(style)])
-	)
+		Object.entries(styles).map(([key, style]): [string, OutStyles] => [
+			key,
+			precompileStyles(style),
+		])
+	) as { [K in keyof Styles]: OutStyles }
 }

--- a/packages/unstyled/src/unstyled-cva.ts
+++ b/packages/unstyled/src/unstyled-cva.ts
@@ -59,9 +59,9 @@ export type CvaProps<T> =
  * Applies component variant props to generate variant-specific styles.
  *
  * This function takes props that specify which variant options are active and
- * returns a {@link OutStyles} object with the corresponding variant
- * styles merged in. Each prop corresponds to a variant name, and the value
- * specifies which option to use for that variant.
+ * returns a {@link OutStyles} object with the corresponding variant styles
+ * merged in. Each prop corresponds to a variant name, and the value specifies
+ * which option to use for that variant.
  *
  * @example
  * 	// Basic usage

--- a/packages/unstyled/src/unstyled-cva.ts
+++ b/packages/unstyled/src/unstyled-cva.ts
@@ -4,13 +4,20 @@ import type { CSSProperties } from "react"
 import { invariant, numberOrStringToString, numberToString } from "utilities"
 import { precompileStyles } from "./unstyled-print"
 import { mapValue, type Value } from "./unstyled-value"
+import type { Vars } from "./unstyled-vars"
 
 export interface Properties extends CSSProperties {
 	[key: `--${string}`]: number | string
 	[key: string]: number | string | undefined
 }
 
+export type DynamicVars = Record<`--${string}`, number | string>
+
 export type RawStyles = { [K in keyof Properties]?: Value<Properties[K]> }
+export type DynamicStyles = (
+	vars: Vars<Record<string, number | string>>
+) => RawStyles
+export type RawStylesV2 = DynamicStyles | RawStyles
 
 type NonEmptyArray<T> = [T, ...T[]]
 

--- a/packages/unstyled/src/unstyled-cva.ts
+++ b/packages/unstyled/src/unstyled-cva.ts
@@ -1,23 +1,16 @@
-import type { PreCompiledStyles } from "./unstyled-print"
+import type { OutStyles } from "./unstyled-print"
 
 import type { CSSProperties } from "react"
 import { invariant, numberOrStringToString, numberToString } from "utilities"
 import { precompileStyles } from "./unstyled-print"
 import { mapValue, type Value } from "./unstyled-value"
-import type { Vars } from "./unstyled-vars"
 
 export interface Properties extends CSSProperties {
 	[key: `--${string}`]: number | string
 	[key: string]: number | string | undefined
 }
 
-export type DynamicVars = Record<`--${string}`, number | string>
-
 export type RawStyles = { [K in keyof Properties]?: Value<Properties[K]> }
-export type DynamicStyles = (
-	vars: Vars<Record<string, number | string>>
-) => RawStyles
-export type RawStylesV2 = DynamicStyles | RawStyles
 
 type NonEmptyArray<T> = [T, ...T[]]
 
@@ -66,7 +59,7 @@ export type CvaProps<T> =
  * Applies component variant props to generate variant-specific styles.
  *
  * This function takes props that specify which variant options are active and
- * returns a {@link PreCompiledStyles} object with the corresponding variant
+ * returns a {@link OutStyles} object with the corresponding variant
  * styles merged in. Each prop corresponds to a variant name, and the value
  * specifies which option to use for that variant.
  *
@@ -86,7 +79,7 @@ export type CvaProps<T> =
  * @returns PreCompiledStyles object containing the variant-specific styles with
  *   CSS custom property references for each variant option
  */
-export function applyProps<T>(props: CvaProps<T>): PreCompiledStyles {
+export function applyProps<T>(props: CvaProps<T>): OutStyles {
 	return precompileStyles(
 		Object.fromEntries(
 			Object.entries(props).map(([key, value]) => [
@@ -161,7 +154,7 @@ export function cva<
 	Variants extends Record<Exclude<string, "css">, Record<string, RawStyles>>,
 >(
 	cva: Cva<Variants>
-): { style: PreCompiledStyles; variants: typeof applyProps<Cva<Variants>> } {
+): { style: OutStyles; variants: typeof applyProps<Cva<Variants>> } {
 	const { base, variants, defaultVariants = {}, compoundVariants = [] } = cva
 
 	const result: RawStyles = { ...base }

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -22,9 +22,14 @@ import { Var } from "./unstyled-vars"
  *   options
  */
 export class PreCompiledStyles {
-	/** @internal */ public readonly dynamicVars: { [K in keyof Properties]?: string }
+	/** @internal */ public readonly dynamicVars: {
+		[K in keyof Properties]?: string
+	}
 	/** @internal */ public readonly styles: { [K in keyof Properties]?: string }
-	constructor(styles: { [K in keyof Properties]?: string }, dynamicVars: { [K in keyof Properties]?: string }) {
+	constructor(
+		styles: { [K in keyof Properties]?: string },
+		dynamicVars: { [K in keyof Properties]?: string }
+	) {
 		this.styles = styles
 		this.dynamicVars = dynamicVars
 	}
@@ -163,14 +168,19 @@ export function precompileStyles<Styles extends RawStylesV2>(
 			new PreCompiledStyles(
 				styles,
 				Object.fromEntries(
-					Object.entries(dynamicVars).map(([key, value]) => [`--${key}`, numberOrStringToString(value)])
+					Object.entries(dynamicVars).map(([key, value]) => [
+						`--${key}`,
+						numberOrStringToString(value),
+					])
 				)
 			)
 	}
 	return new PreCompiledStyles(precompileStaticStyles(style), {})
 }
 
-export function precompileStaticStyles(style: RawStyles): { [K in keyof Properties]?: string } {
+export function precompileStaticStyles(style: RawStyles): {
+	[K in keyof Properties]?: string
+} {
 	return Object.fromEntries(
 		Object.entries(style).flatMap(([propertyName, property]) => {
 			if (property === undefined) return []

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -1,6 +1,13 @@
 import { numberOrStringToString } from "utilities"
-import type { Properties, RawStyles } from "./unstyled-cva"
+import type {
+	DynamicStyles,
+	DynamicVars,
+	Properties,
+	RawStyles,
+	RawStylesV2,
+} from "./unstyled-cva"
 import type { Value } from "./unstyled-value"
+import { Var } from "./unstyled-vars"
 
 /**
  * Compiled styles object representing pre-processed CSS styles.
@@ -15,9 +22,11 @@ import type { Value } from "./unstyled-value"
  *   options
  */
 export class PreCompiledStyles {
+	/** @internal */ public readonly dynamicVars: { [K in keyof Properties]?: string }
 	/** @internal */ public readonly styles: { [K in keyof Properties]?: string }
-	constructor(styles: { [K in keyof Properties]?: string }) {
+	constructor(styles: { [K in keyof Properties]?: string }, dynamicVars: { [K in keyof Properties]?: string }) {
 		this.styles = styles
+		this.dynamicVars = dynamicVars
 	}
 }
 
@@ -50,10 +59,11 @@ export class PreCompiledStyles {
 export function mergeStyles(
 	...styles: (PreCompiledStyles | undefined)[]
 ): PreCompiledStyles {
-	const result = new PreCompiledStyles({})
+	const result = new PreCompiledStyles({}, {})
 	for (const style of styles) {
 		if (style === undefined) continue
 		void Object.assign(result.styles, style.styles)
+		void Object.assign(result.dynamicVars, style.dynamicVars)
 	}
 	return result
 }
@@ -132,26 +142,65 @@ export function print(style: PreCompiledStyles): string {
  * @returns {@link PreCompiledStyles} Instance containing the compiled styles
  *   accessible via the `.styles` property
  */
-export function precompileStyles(style: RawStyles): PreCompiledStyles {
-	return new PreCompiledStyles(
-		Object.fromEntries(
-			Object.entries(style).flatMap(([propertyName, property]) => {
-				if (property === undefined) return []
-
-				return [
-					[
-						propertyName,
-						printProperty(
-							propertyName.replace(/([A-Z])/g, "-$1").toLowerCase(),
-							property,
-							1
-						),
-					],
-				]
-			})
+export function precompileStyles<Styles extends RawStylesV2>(
+	style: Styles
+): PrecompileStyles<Styles> {
+	if (typeof style === "function") {
+		const styles = precompileStaticStyles(
+			style(
+				new Proxy(
+					{},
+					{
+						get(target, key: string) {
+							return new Var(key)
+						},
+					}
+				)
+			)
 		)
+
+		return (dynamicVars: DynamicVars) =>
+			new PreCompiledStyles(
+				styles,
+				Object.fromEntries(
+					Object.entries(dynamicVars).map(([key, value]) => [`--${key}`, numberOrStringToString(value)])
+				)
+			)
+	}
+	return new PreCompiledStyles(precompileStaticStyles(style), {})
+}
+
+export function precompileStaticStyles(style: RawStyles): { [K in keyof Properties]?: string } {
+	return Object.fromEntries(
+		Object.entries(style).flatMap(([propertyName, property]) => {
+			if (property === undefined) return []
+
+			return [
+				[
+					propertyName,
+					printProperty(
+						propertyName.replace(/([A-Z])/g, "-$1").toLowerCase(),
+						property,
+						1
+					),
+				],
+			]
+		})
 	)
 }
+
+export type PrecompileStyles<Styles extends RawStylesV2> =
+	Styles extends RawStyles
+		? Styles
+		: Styles extends DynamicStyles
+			? (vars: {
+					[K in keyof Parameters<Styles>[0]]: Parameters<Styles>[0] extends Var<
+						infer T
+					>
+						? T
+						: never
+				}) => ReturnType<Styles>
+			: never
 
 const tab = "  "
 

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -29,10 +29,9 @@ export type DynamicVars = Record<`--${string}`, string>
 /**
  * Merges multiple {@link OutStyles} objects into one.
  *
- * This function combines multiple style objects into a single
- * {@link OutStyles} instance by iterating over each input and assigning
- * its properties to the result. Undefined properties are skipped during the
- * merge.
+ * This function combines multiple style objects into a single {@link OutStyles}
+ * instance by iterating over each input and assigning its properties to the
+ * result. Undefined properties are skipped during the merge.
  *
  * This is useful for combining base styles with variant-specific styles or
  * merging theme styles with component-specific overrides.
@@ -65,9 +64,9 @@ export function mergeStyles(...styles: (OutStyles | undefined)[]): OutStyles {
 /**
  * Converts {@link OutStyles} to a CSS string representation.
  *
- * This function takes a {@link OutStyles} instance and generates a CSS
- * string by iterating over all properties and values. The output CSS uses CSS
- * custom properties (CSS variables) for variant options.
+ * This function takes a {@link OutStyles} instance and generates a CSS string by
+ * iterating over all properties and values. The output CSS uses CSS custom
+ * properties (CSS variables) for variant options.
  *
  * @example
  * 	// Simple styles
@@ -99,8 +98,8 @@ export function print(style: OutStyles): string {
  * Compiles raw styles into {@link OutStyles} for optimized rendering.
  *
  * This function takes an object with CSS properties and their values, which can
- * include media query objects, and returns a {@link OutStyles} instance
- * that can be directly used with CSS generation functions.
+ * include media query objects, and returns a {@link OutStyles} instance that can
+ * be directly used with CSS generation functions.
  *
  * The compilation process flattens nested media query objects and creates a
  * structured representation that can be efficiently processed for CSS output.

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -1,18 +1,11 @@
 import { numberOrStringToString } from "utilities"
-import type {
-	DynamicStyles,
-	DynamicVars,
-	Properties,
-	RawStyles,
-	RawStylesV2,
-} from "./unstyled-cva"
+import type { Properties, RawStyles } from "./unstyled-cva"
 import type { Value } from "./unstyled-value"
-import { Var } from "./unstyled-vars"
 
 /**
  * Compiled styles object representing pre-processed CSS styles.
  *
- * {@link PreCompiledStyles} is a wrapper around a styles object that provides a
+ * {@link OutStyles} is a wrapper around a styles object that provides a
  * structured representation of compiled CSS. The styles property contains CSS
  * properties with values that may include CSS custom properties for variant
  * options.
@@ -21,25 +14,23 @@ import { Var } from "./unstyled-vars"
  *   can be simple strings/numbers or CSS custom properties referencing variant
  *   options
  */
-export class PreCompiledStyles {
-	/** @internal */ public readonly dynamicVars: {
-		[K in keyof Properties]?: string
-	}
-	/** @internal */ public readonly styles: { [K in keyof Properties]?: string }
-	constructor(
-		styles: { [K in keyof Properties]?: string },
-		dynamicVars: { [K in keyof Properties]?: string }
-	) {
-		this.styles = styles
+export class OutStyles {
+	/** @internal */ public readonly dynamicVars: DynamicVars
+	/** @internal */ public readonly preCompiledStyles: PreCompiledStyles
+	constructor(preCompiledStyles: PreCompiledStyles, dynamicVars: DynamicVars) {
+		this.preCompiledStyles = preCompiledStyles
 		this.dynamicVars = dynamicVars
 	}
 }
 
+export type PreCompiledStyles = { [K in keyof Properties]?: string }
+export type DynamicVars = Record<`--${string}`, string>
+
 /**
- * Merges multiple {@link PreCompiledStyles} objects into one.
+ * Merges multiple {@link OutStyles} objects into one.
  *
  * This function combines multiple style objects into a single
- * {@link PreCompiledStyles} instance by iterating over each input and assigning
+ * {@link OutStyles} instance by iterating over each input and assigning
  * its properties to the result. Undefined properties are skipped during the
  * merge.
  *
@@ -61,22 +52,20 @@ export class PreCompiledStyles {
  *   input objects. The result's styles property includes properties from all
  *   inputs in the order they were provided
  */
-export function mergeStyles(
-	...styles: (PreCompiledStyles | undefined)[]
-): PreCompiledStyles {
-	const result = new PreCompiledStyles({}, {})
+export function mergeStyles(...styles: (OutStyles | undefined)[]): OutStyles {
+	const result = new OutStyles({}, {})
 	for (const style of styles) {
 		if (style === undefined) continue
-		void Object.assign(result.styles, style.styles)
+		void Object.assign(result.preCompiledStyles, style.preCompiledStyles)
 		void Object.assign(result.dynamicVars, style.dynamicVars)
 	}
 	return result
 }
 
 /**
- * Converts {@link PreCompiledStyles} to a CSS string representation.
+ * Converts {@link OutStyles} to a CSS string representation.
  *
- * This function takes a {@link PreCompiledStyles} instance and generates a CSS
+ * This function takes a {@link OutStyles} instance and generates a CSS
  * string by iterating over all properties and values. The output CSS uses CSS
  * custom properties (CSS variables) for variant options.
  *
@@ -90,15 +79,15 @@ export function mergeStyles(
  * 	const css = print(styles)
  * 	// Output: "{\n  color: blue;\n  --size-xs: var(--size-xs);\n}"
  *
- * @param style - {@link PreCompiledStyles} instance to convert to CSS string
+ * @param style - {@link OutStyles} instance to convert to CSS string
  * @returns CSS string representing the compiled styles. The string includes all
  *   properties with their values, using CSS custom properties for variant
  *   options in the format var(--variant-option)
  * @internal
  */
-export function print(style: PreCompiledStyles): string {
+export function print(style: OutStyles): string {
 	let result = "{\n"
-	for (const property of Object.values(style.styles)) {
+	for (const property of Object.values(style.preCompiledStyles)) {
 		if (property === undefined) continue
 		result += property
 	}
@@ -107,10 +96,10 @@ export function print(style: PreCompiledStyles): string {
 }
 
 /**
- * Compiles raw styles into {@link PreCompiledStyles} for optimized rendering.
+ * Compiles raw styles into {@link OutStyles} for optimized rendering.
  *
  * This function takes an object with CSS properties and their values, which can
- * include media query objects, and returns a {@link PreCompiledStyles} instance
+ * include media query objects, and returns a {@link OutStyles} instance
  * that can be directly used with CSS generation functions.
  *
  * The compilation process flattens nested media query objects and creates a
@@ -147,70 +136,28 @@ export function print(style: PreCompiledStyles): string {
  * @returns {@link PreCompiledStyles} Instance containing the compiled styles
  *   accessible via the `.styles` property
  */
-export function precompileStyles<Styles extends RawStylesV2>(
-	style: Styles
-): PrecompileStyles<Styles> {
-	if (typeof style === "function") {
-		const styles = precompileStaticStyles(
-			style(
-				new Proxy(
-					{},
-					{
-						get(target, key: string) {
-							return new Var(key)
-						},
-					}
-				)
-			)
-		)
 
-		return (dynamicVars: DynamicVars) =>
-			new PreCompiledStyles(
-				styles,
-				Object.fromEntries(
-					Object.entries(dynamicVars).map(([key, value]) => [
-						`--${key}`,
-						numberOrStringToString(value),
-					])
-				)
-			)
-	}
-	return new PreCompiledStyles(precompileStaticStyles(style), {})
-}
+export function precompileStyles(style: RawStyles): OutStyles {
+	return new OutStyles(
+		Object.fromEntries(
+			Object.entries(style).flatMap(([propertyName, property]) => {
+				if (property === undefined) return []
 
-export function precompileStaticStyles(style: RawStyles): {
-	[K in keyof Properties]?: string
-} {
-	return Object.fromEntries(
-		Object.entries(style).flatMap(([propertyName, property]) => {
-			if (property === undefined) return []
-
-			return [
-				[
-					propertyName,
-					printProperty(
-						propertyName.replace(/([A-Z])/g, "-$1").toLowerCase(),
-						property,
-						1
-					),
-				],
-			]
-		})
+				return [
+					[
+						propertyName,
+						printProperty(
+							propertyName.replace(/([A-Z])/g, "-$1").toLowerCase(),
+							property,
+							1
+						),
+					],
+				]
+			})
+		),
+		{}
 	)
 }
-
-export type PrecompileStyles<Styles extends RawStylesV2> =
-	Styles extends RawStyles
-		? Styles
-		: Styles extends DynamicStyles
-			? (vars: {
-					[K in keyof Parameters<Styles>[0]]: Parameters<Styles>[0] extends Var<
-						infer T
-					>
-						? T
-						: never
-				}) => ReturnType<Styles>
-			: never
 
 const tab = "  "
 

--- a/packages/unstyled/src/unstyled-use-styles.tsx
+++ b/packages/unstyled/src/unstyled-use-styles.tsx
@@ -1,5 +1,6 @@
-import { useMemo, type ReactNode } from "react"
+import { useState, type ReactNode } from "react"
 import { invariant, numberToString } from "utilities"
+import type { DynamicVars } from "./unstyled-cva"
 import { print, type PreCompiledStyles } from "./unstyled-print"
 
 /**
@@ -34,8 +35,10 @@ import { print, type PreCompiledStyles } from "./unstyled-print"
  *
  * 	@internal Box should be used instead of this hook directly. This is an internal implementation detail
  */
-export function useStyles(rawStyle: PreCompiledStyles): [string, ReactNode] {
-	return useMemo(() => {
+export function useStyles(
+	rawStyle: PreCompiledStyles
+): [string, ReactNode, DynamicVars] {
+	return useState((): [string, ReactNode, DynamicVars] => {
 		const styles = print(rawStyle)
 		const thing = sha256()
 		thing.add(JSON.stringify(rawStyle))
@@ -49,8 +52,9 @@ export function useStyles(rawStyle: PreCompiledStyles): [string, ReactNode] {
 				href={className}
 				precedence="medium"
 			>{`.${className} ${styles}`}</style>,
+			rawStyle.dynamicVars,
 		]
-	}, [rawStyle])
+	})[0]
 }
 
 /*

--- a/packages/unstyled/src/unstyled-use-styles.tsx
+++ b/packages/unstyled/src/unstyled-use-styles.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from "react"
 import { invariant, numberToString } from "utilities"
-import type { DynamicVars } from "./unstyled-cva"
-import { print, type PreCompiledStyles } from "./unstyled-print"
+
+import { print, type DynamicVars, type OutStyles } from "./unstyled-print"
 
 /**
  * React hook that generates style classes for unstyled components.
@@ -25,7 +25,7 @@ import { print, type PreCompiledStyles } from "./unstyled-print"
  *
  * 	return <div className={className} />;
  *
- * 	@param rawStyle - {@link PreCompiledStyles} instance containing the styles to
+ * 	@param rawStyle - {@link OutStyles} instance containing the styles to
  * 	generate a class name for. The styles are converted to a CSS string and
  * 	injected into the document.
  * 	@returns A tuple containing:
@@ -36,7 +36,7 @@ import { print, type PreCompiledStyles } from "./unstyled-print"
  * 	@internal Box should be used instead of this hook directly. This is an internal implementation detail
  */
 export function useStyles(
-	rawStyle: PreCompiledStyles
+	rawStyle: OutStyles
 ): [string, ReactNode, DynamicVars] {
 	return useState((): [string, ReactNode, DynamicVars] => {
 		const styles = print(rawStyle)

--- a/packages/unstyled/src/unstyled-vars.tsx
+++ b/packages/unstyled/src/unstyled-vars.tsx
@@ -1,4 +1,5 @@
-import { numberOrStringToString, numberToString } from "utilities"
+import { numberOrStringToString } from "utilities"
+import { OutStyles } from "./unstyled-print"
 
 export type Vars<Vars extends Record<string, number | string>> = {
 	[K in keyof Vars]: Var<Vars[K]>
@@ -6,8 +7,8 @@ export type Vars<Vars extends Record<string, number | string>> = {
 
 export class Var<_T extends number | string> {
 	/** @internal */
-	public name: string
-	constructor(name: string) {
+	public name: `--${string}`
+	constructor(name: `--${string}`) {
 		this.name = name
 	}
 }
@@ -16,5 +17,15 @@ export function is<T extends number | string>(
 	_var: Var<T>,
 	...values: readonly [T, ...T[]]
 ) {
-	return `@container ${values.map((value) => `style(--${_var.name}: ${numberOrStringToString(value)})`).join(" or ")}`
+	return `@container ${values.map((value) => `style(${_var.name}: ${numberOrStringToString(value)})`).join(" or ")}`
+}
+
+export function provide<T extends number | string>(
+	_var: Var<T>,
+	value: T
+): OutStyles {
+	return new OutStyles(
+		{},
+		{ [_var.name]: numberOrStringToString(value) }
+	)
 }

--- a/packages/unstyled/src/unstyled-vars.tsx
+++ b/packages/unstyled/src/unstyled-vars.tsx
@@ -24,8 +24,5 @@ export function provide<T extends number | string>(
 	_var: Var<T>,
 	value: T
 ): OutStyles {
-	return new OutStyles(
-		{},
-		{ [_var.name]: numberOrStringToString(value) }
-	)
+	return new OutStyles({}, { [_var.name]: numberOrStringToString(value) })
 }

--- a/packages/unstyled/src/unstyled-vars.tsx
+++ b/packages/unstyled/src/unstyled-vars.tsx
@@ -1,0 +1,20 @@
+import { numberOrStringToString, numberToString } from "utilities"
+
+export type Vars<Vars extends Record<string, number | string>> = {
+	[K in keyof Vars]: Var<Vars[K]>
+}
+
+export class Var<_T extends number | string> {
+	/** @internal */
+	public name: string
+	constructor(name: string) {
+		this.name = name
+	}
+}
+
+export function is<T extends number | string>(
+	_var: Var<T>,
+	...values: readonly [T, ...T[]]
+) {
+	return `@container ${values.map((value) => `style(--${_var.name}: ${numberOrStringToString(value)})`).join(" or ")}`
+}

--- a/packages/unstyled/src/unstyled.ts
+++ b/packages/unstyled/src/unstyled.ts
@@ -1,2 +1,4 @@
 export * from "./unstyled-cva"
 export * from "./unstyled-print"
+export * from "./unstyled-create"
+export * from "./unstyled-vars"


### PR DESCRIPTION
## Summary by Sourcery

Introduce dynamic CSS variable-based styling pipeline and update button and layout components to consume the new OutStyles API.

New Features:
- Add support for declaring and providing dynamic CSS variables via Var, is, and provide helpers and a create utility for compiling style maps to OutStyles.
- Implement a new button styling factory that uses dynamic CSS variables and container-style queries for color, size, and shape variants.

Enhancements:
- Refactor the core styling representation from PreCompiledStyles to OutStyles, augmenting compiled styles with dynamic variable metadata and updating merge, print, and precompile utilities accordingly.
- Extend the design utilities with a typescale helper and adjust design token typescale definitions to expose concrete typography primitives.
- Update Box, layout primitives, theme typing, and list-related components to work with OutStyles and pass dynamic variables through to the DOM via a wrapper element.
- Adjust useStyles to return dynamic variable maps alongside generated class names and style elements to support runtime variable injection.