### PR TITLE
strictDepBuilds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,6 +122,13 @@ cleanupUnusedCatalogs: true
 # trustPolicyIgnoreAfter: 4320
 dedupePeers: true
 enablePrePostScripts: false
+ignoredBuiltDependencies:
+  - '@sentry/cli'
+  - esbuild
+  - msw
+  - sharp
+  - workerd
+
 nodeLinker: hoisted
 optimisticRepeatInstall: true
 strictDepBuilds: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,6 +124,7 @@ dedupePeers: true
 enablePrePostScripts: false
 nodeLinker: hoisted
 optimisticRepeatInstall: true
+strictDepBuilds: true
 onlyBuiltDependencies:
   - electron
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Enable pnpm's strictDepBuilds option in the workspace configuration to enforce stricter dependency build behavior.