### PR TITLE
🔧 fix: correct relay schema path to root node_modules

### DIFF
--- a/apps/web/relay.config.json
+++ b/apps/web/relay.config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "./node_modules/relay-compiler/relay-compiler-config-schema.json",
+	"$schema": "../../node_modules/relay-compiler/relay-compiler-config-schema.json",
 	"src": "./app",
 	"language": "typescript",
 	"schema": "./schema.graphql",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update Relay config to point schema path at the root-level node_modules package.