### PR TITLE
use macros

### DIFF
--- a/apps/web/app/components/Badge.styles.tsx
+++ b/apps/web/app/components/Badge.styles.tsx
@@ -1,20 +1,19 @@
 import { tokens } from "@anitrove/design"
 import { precompileStyles } from "@anitrove/unstyled"
 
-
 export const styles = precompileStyles({
-  backgroundColor: tokens.colors.error,
-  ...tokens.typescale["label-sm"],
-  color: tokens.colors["on-error"],
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  borderRadius: tokens.borderRadius.sm,
-  padding: ".25rem",
-  position: "absolute",
-  right: 0,
-  top: 0,
-  transform: "translate(25%, -25%)",
-  minWidth: "1rem",
-  height: "1rem",
+	backgroundColor: tokens.colors.error,
+	...tokens.typescale["label-sm"],
+	color: tokens.colors["on-error"],
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	borderRadius: tokens.borderRadius.sm,
+	padding: ".25rem",
+	position: "absolute",
+	right: 0,
+	top: 0,
+	transform: "translate(25%, -25%)",
+	minWidth: "1rem",
+	height: "1rem",
 })

--- a/apps/web/app/components/Badge.styles.tsx
+++ b/apps/web/app/components/Badge.styles.tsx
@@ -1,0 +1,20 @@
+import { tokens } from "@anitrove/design"
+import { precompileStyles } from "@anitrove/unstyled"
+
+
+export const styles = precompileStyles({
+  backgroundColor: tokens.colors.error,
+  ...tokens.typescale["label-sm"],
+  color: tokens.colors["on-error"],
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: tokens.borderRadius.sm,
+  padding: ".25rem",
+  position: "absolute",
+  right: 0,
+  top: 0,
+  transform: "translate(25%, -25%)",
+  minWidth: "1rem",
+  height: "1rem",
+})

--- a/apps/web/app/components/Badge.tsx
+++ b/apps/web/app/components/Badge.tsx
@@ -1,34 +1,9 @@
-import { tokens } from "@anitrove/design"
-import { cva, mergeStyles } from "@anitrove/unstyled"
+import { mergeStyles } from "@anitrove/unstyled"
 import { Box, type BoxProps } from "@anitrove/unstyled/box"
-
-const styles = cva({
-	base: {
-		backgroundColor: tokens.colors.error,
-		...tokens.typescale["label-sm"],
-		color: tokens.colors["on-error"],
-		display: "flex",
-		alignItems: "center",
-		justifyContent: "center",
-		borderRadius: tokens.borderRadius.sm,
-		padding: ".25rem",
-		position: "absolute",
-		right: 0,
-		top: 0,
-		transform: "translate(25%, -25%)",
-		minWidth: "1rem",
-		height: "1rem",
-	},
-	variants: {},
-})
+import { styles } from "./Badge.styles" with { type: "macro" }
 
 interface BadgeProps extends BoxProps {}
 
 export function Badge(props: BadgeProps) {
-	return (
-		<Box
-			{...props}
-			style={mergeStyles(styles.style, styles.variants({}), props.style)}
-		></Box>
-	)
+	return <Box {...props} style={mergeStyles(styles, props.style)}></Box>
 }

--- a/apps/web/app/components/Breadcrumb.styles.tsx
+++ b/apps/web/app/components/Breadcrumb.styles.tsx
@@ -1,0 +1,12 @@
+import { utilities } from "@anitrove/design"
+import { create } from "@anitrove/unstyled"
+
+export const styles = create({
+	breadcrumb: { ...utilities.lineClamp(1) },
+	item: {
+		...utilities.marginX({ "&:before": "0.25rem" }),
+		display: "inline-block",
+		content: { "&:first-child": { "&::before": "''" }, "&::before": "'/'" },
+		textDecoration: { "&:hover": "underline" },
+	},
+})

--- a/apps/web/app/components/Breadcrumb.tsx
+++ b/apps/web/app/components/Breadcrumb.tsx
@@ -1,28 +1,21 @@
 import { A } from "@anitrove/a"
-import { utilities } from "@anitrove/design"
-import { precompileStyles } from "@anitrove/unstyled"
 import { Box } from "@anitrove/unstyled/box"
 import { Role, type RoleProps } from "@ariakit/react"
 import type { ComponentProps } from "react"
 import { useLocation, useResolvedPath } from "react-router"
+import { styles } from "./Breadcrumb.styles" with { type: "macro" }
 
-const breadcrumbStyles = precompileStyles({ ...utilities.lineClamp(1) })
 export function Breadcrumb(props: RoleProps<"nav">) {
 	return (
 		<Role.nav aria-label="Breadcrumb" {...props}>
 			<Box
 				render={<Role.ol>{props.children}</Role.ol>}
-				style={breadcrumbStyles}
+				style={styles.breadcrumb}
 			></Box>
 		</Role.nav>
 	)
 }
 
-const breadcrumbItemStyles = precompileStyles({
-	...utilities.marginX({ "&:before": "0.25rem" }),
-	display: "inline-block",
-	content: { "&:first-child": { "&::before": "''" }, "&::before": "'/'" },
-})
 export function BreadcrumbItem(props: ComponentProps<typeof A>) {
 	const { pathname } = useResolvedPath(props.href, { relative: props.relative })
 
@@ -38,7 +31,7 @@ export function BreadcrumbItem(props: ComponentProps<typeof A>) {
 					></A>
 				</Role.li>
 			}
-			style={breadcrumbItemStyles}
+			style={styles.item}
 		></Box>
 	)
 }

--- a/apps/web/app/lib/theme/index.tsx
+++ b/apps/web/app/lib/theme/index.tsx
@@ -1,12 +1,12 @@
 import {
-    argbFromHex,
-    blueFromArgb,
-    DynamicColor,
-    greenFromArgb,
-    Hct,
-    MaterialDynamicColors,
-    redFromArgb,
-    SchemeTonalSpot,
+	argbFromHex,
+	blueFromArgb,
+	DynamicColor,
+	greenFromArgb,
+	Hct,
+	MaterialDynamicColors,
+	redFromArgb,
+	SchemeTonalSpot,
 } from "@material/material-color-utilities"
 import type { CSSProperties } from "react"
 

--- a/apps/web/app/lib/theme/index.tsx
+++ b/apps/web/app/lib/theme/index.tsx
@@ -1,17 +1,18 @@
 import {
-	argbFromHex,
-	blueFromArgb,
-	DynamicColor,
-	greenFromArgb,
-	Hct,
-	MaterialDynamicColors,
-	redFromArgb,
-	SchemeTonalSpot,
+    argbFromHex,
+    blueFromArgb,
+    DynamicColor,
+    greenFromArgb,
+    Hct,
+    MaterialDynamicColors,
+    redFromArgb,
+    SchemeTonalSpot,
 } from "@material/material-color-utilities"
 import type { CSSProperties } from "react"
 
 import colors from "@anitrove/design/colors"
-import { precompileStyles, type OutStyles } from "@anitrove/unstyled"
+import { precompileStyles } from "@anitrove/unstyled"
+import { type OutStyles } from "@anitrove/unstyled"
 
 export type Theme = OutStyles
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -94,6 +94,7 @@
 		"temporal-polyfill-lite": "catalog:",
 		"ts-config": "workspace:@animedes/ts-config@*",
 		"tsx": "catalog:",
+		"unplugin-macros": "catalog:",
 		"vite-plugin-babel": "catalog:",
 		"vite-plugin-inspect": "catalog:",
 		"vitest": "catalog:"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from "vite"
 import babel from "vite-plugin-babel"
 import inspect from "vite-plugin-inspect"
 import relay from "vite-plugin-relay"
-import macros from 'unplugin-macros/vite'
+import macros from "unplugin-macros/vite"
 
 export default defineConfig({
 	plugins: [

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,10 +7,12 @@ import { defineConfig } from "vite"
 import babel from "vite-plugin-babel"
 import inspect from "vite-plugin-inspect"
 import relay from "vite-plugin-relay"
+import macros from 'unplugin-macros/vite'
 
 export default defineConfig({
 	plugins: [
 		inspect(),
+		macros(),
 		tailwindcss(),
 		babel({
 			filter: /\.[jt]sx?$/,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,7 +3,7 @@ import { reactRouter } from "@react-router/dev/vite"
 import { sentryVitePlugin as sentry } from "@sentry/vite-plugin"
 import tailwindcss from "@tailwindcss/vite"
 import icons from "unplugin-icons/vite"
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
 import babel from "vite-plugin-babel"
 import inspect from "vite-plugin-inspect"
 import relay from "vite-plugin-relay"
@@ -12,7 +12,7 @@ import macros from "unplugin-macros/vite"
 export default defineConfig({
 	plugins: [
 		inspect(),
-		macros(),
+		macros() as Plugin,
 		tailwindcss(),
 		babel({
 			filter: /\.[jt]sx?$/,

--- a/packages/design/src/design-tokens.ts
+++ b/packages/design/src/design-tokens.ts
@@ -1,7 +1,7 @@
 import { type Properties, type RawStyles } from "@anitrove/unstyled"
 
-import type Colors from "./design-colors"
-import fonts, { letterSpacing, pxToRem } from "./design-fonts"
+import type Colors from "./design-colors.ts"
+import fonts, { letterSpacing, pxToRem } from "./design-fonts.ts"
 
 export const borderRadius = {
 	none: "0",

--- a/packages/design/src/design-utilities.ts
+++ b/packages/design/src/design-utilities.ts
@@ -2,9 +2,9 @@ import { mapValue, type Value } from "@anitrove/unstyled/value"
 
 import type { RawStyles } from "@anitrove/unstyled"
 import type { Property } from "csstype"
-import colors from "./design-colors"
+import colors from "./design-colors.ts"
 
-import * as tokens from "./design-tokens"
+import * as tokens from "./design-tokens.ts"
 
 export function typescale(scale: Value<keyof typeof tokens.typescale>) {
 	return {

--- a/packages/design/src/design.ts
+++ b/packages/design/src/design.ts
@@ -1,7 +1,7 @@
 import { numberToString } from "utilities"
 import { type Value, mapValue } from "@anitrove/unstyled/value"
-export * as utilities from "./design-utilities"
-export * as tokens from "./design-tokens"
+export * as utilities from "./design-utilities.ts"
+export * as tokens from "./design-tokens.ts"
 
 const states = { none: 0, hover: 0.08, focus: 0.1, pressed: 0.1, dragged: 0.16 }
 

--- a/packages/unstyled/src/unstyled-box.tsx
+++ b/packages/unstyled/src/unstyled-box.tsx
@@ -1,7 +1,7 @@
 import { Role, type RoleProps } from "@ariakit/react"
 import type { ReactNode } from "react"
-import { mergeStyles, type OutStyles } from "./unstyled-print"
-import { useStyles } from "./unstyled-use-styles"
+import { mergeStyles, type OutStyles } from "./unstyled-print.ts"
+import { useStyles } from "./unstyled-use-styles.tsx"
 
 export interface BoxProps extends Omit<RoleProps, "className" | "style"> {
 	style?: OutStyles

--- a/packages/unstyled/src/unstyled-create.ts
+++ b/packages/unstyled/src/unstyled-create.ts
@@ -1,5 +1,5 @@
-import type { RawStyles } from "./unstyled-cva"
-import { precompileStyles, type OutStyles } from "./unstyled-print"
+import type { RawStyles } from "./unstyled-cva.ts"
+import { precompileStyles, type OutStyles } from "./unstyled-print.ts"
 
 export function create<const Styles extends Record<string, RawStyles>>(
 	styles: Styles

--- a/packages/unstyled/src/unstyled-cva.bench.ts
+++ b/packages/unstyled/src/unstyled-cva.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from "vitest"
-import { cva } from "./unstyled-cva"
+import { cva } from "./unstyled-cva.ts"
 
 bench("empty", () => {
 	void cva({ base: {}, variants: {} })

--- a/packages/unstyled/src/unstyled-cva.spec.ts
+++ b/packages/unstyled/src/unstyled-cva.spec.ts
@@ -1,9 +1,9 @@
 import { expect, it, vi } from "vitest"
 
 import { numberToString } from "utilities"
-import { cva } from "./unstyled-cva"
-import { precompileStyles } from "./unstyled-print"
-import { mapValue, type Value } from "./unstyled-value"
+import { cva } from "./unstyled-cva.ts"
+import { precompileStyles } from "./unstyled-print.ts"
+import { mapValue, type Value } from "./unstyled-value.ts"
 
 const states = { none: 0, hover: 0.08, focus: 0.1, pressed: 0.1, dragged: 0.16 }
 

--- a/packages/unstyled/src/unstyled-cva.ts
+++ b/packages/unstyled/src/unstyled-cva.ts
@@ -1,9 +1,9 @@
-import type { OutStyles } from "./unstyled-print"
+import type { OutStyles } from "./unstyled-print.ts"
 
 import type { CSSProperties } from "react"
 import { invariant, numberOrStringToString, numberToString } from "utilities"
-import { precompileStyles } from "./unstyled-print"
-import { mapValue, type Value } from "./unstyled-value"
+import { precompileStyles } from "./unstyled-print.ts"
+import { mapValue, type Value } from "./unstyled-value.ts"
 
 export interface Properties extends CSSProperties {
 	[key: `--${string}`]: number | string

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -1,6 +1,6 @@
 import { numberOrStringToString } from "utilities"
-import type { Properties, RawStyles } from "./unstyled-cva"
-import type { Value } from "./unstyled-value"
+import type { Properties, RawStyles } from "./unstyled-cva.ts"
+import type { Value } from "./unstyled-value.ts"
 
 /**
  * Compiled styles object representing pre-processed CSS styles.
@@ -14,13 +14,9 @@ import type { Value } from "./unstyled-value"
  *   can be simple strings/numbers or CSS custom properties referencing variant
  *   options
  */
-export class OutStyles {
-	/** @internal */ public readonly dynamicVars: DynamicVars
-	/** @internal */ public readonly preCompiledStyles: PreCompiledStyles
-	constructor(preCompiledStyles: PreCompiledStyles, dynamicVars: DynamicVars) {
-		this.preCompiledStyles = preCompiledStyles
-		this.dynamicVars = dynamicVars
-	}
+export interface OutStyles {
+	/** @internal */ readonly dynamicVars: DynamicVars
+	/** @internal */ readonly preCompiledStyles: PreCompiledStyles
 }
 
 export type PreCompiledStyles = { [K in keyof Properties]?: string }
@@ -52,7 +48,7 @@ export type DynamicVars = Record<`--${string}`, string>
  *   inputs in the order they were provided
  */
 export function mergeStyles(...styles: (OutStyles | undefined)[]): OutStyles {
-	const result = new OutStyles({}, {})
+	const result: OutStyles = { preCompiledStyles: {}, dynamicVars: {} }
 	for (const style of styles) {
 		if (style === undefined) continue
 		void Object.assign(result.preCompiledStyles, style.preCompiledStyles)
@@ -137,8 +133,8 @@ export function print(style: OutStyles): string {
  */
 
 export function precompileStyles(style: RawStyles): OutStyles {
-	return new OutStyles(
-		Object.fromEntries(
+	return {
+		preCompiledStyles: Object.fromEntries(
 			Object.entries(style).flatMap(([propertyName, property]) => {
 				if (property === undefined) return []
 
@@ -154,8 +150,8 @@ export function precompileStyles(style: RawStyles): OutStyles {
 				]
 			})
 		),
-		{}
-	)
+		dynamicVars: {},
+	}
 }
 
 const tab = "  "

--- a/packages/unstyled/src/unstyled-value.ts
+++ b/packages/unstyled/src/unstyled-value.ts
@@ -1,4 +1,4 @@
-import type { Properties } from "./unstyled-cva"
+import type { Properties } from "./unstyled-cva.ts"
 
 export type Value<
 	T extends Properties[keyof Properties] = Properties[keyof Properties],

--- a/packages/unstyled/src/unstyled-vars.ts
+++ b/packages/unstyled/src/unstyled-vars.ts
@@ -1,5 +1,5 @@
 import { numberOrStringToString } from "utilities"
-import { OutStyles } from "./unstyled-print"
+import type { OutStyles } from "./unstyled-print.ts"
 
 export type Vars<Vars extends Record<string, number | string>> = {
 	[K in keyof Vars]: Var<Vars[K]>
@@ -24,5 +24,8 @@ export function provide<T extends number | string>(
 	_var: Var<T>,
 	value: T
 ): OutStyles {
-	return new OutStyles({}, { [_var.name]: numberOrStringToString(value) })
+	return {
+		preCompiledStyles: {},
+		dynamicVars: { [_var.name]: numberOrStringToString(value) },
+	}
 }

--- a/packages/unstyled/src/unstyled.ts
+++ b/packages/unstyled/src/unstyled.ts
@@ -1,4 +1,5 @@
-export * from "./unstyled-cva"
-export * from "./unstyled-print"
-export * from "./unstyled-create"
-export * from "./unstyled-vars"
+export * from "./unstyled-create.ts"
+export * from "./unstyled-cva.ts"
+export * from "./unstyled-print.ts"
+export * from "./unstyled-vars.ts"
+

--- a/packages/unstyled/src/unstyled.ts
+++ b/packages/unstyled/src/unstyled.ts
@@ -2,4 +2,3 @@ export * from "./unstyled-create.ts"
 export * from "./unstyled-cva.ts"
 export * from "./unstyled-print.ts"
 export * from "./unstyled-vars.ts"
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ catalogs:
     unplugin-icons:
       specifier: 23.0.1
       version: 23.0.1
+    unplugin-macros:
+      specifier: 0.20.0
+      version: 0.20.0
     vite:
       specifier: 8.0.11
       version: 8.0.11
@@ -339,7 +342,7 @@ importers:
         version: 9.6.1(@types/node@24.12.3)
       '@stryker-mutator/vitest-runner':
         specifier: 'catalog:'
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.12.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.12.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -390,7 +393,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
         specifier: 'catalog:'
         version: 4.88.0
@@ -675,6 +678,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
+      unplugin-macros:
+        specifier: 'catalog:'
+        version: 0.20.0(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(rolldown@1.0.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-babel:
         specifier: 'catalog:'
         version: 1.6.0(@babel/core@7.29.0)(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -846,7 +852,7 @@ importers:
         version: 2.3.1(eslint@10.3.0(jiti@2.6.1))
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
-        version: 3.1.0(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 3.1.0(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       ts-config:
         specifier: workspace:@animedes/ts-config@*
         version: link:../ts-config
@@ -855,7 +861,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eslint-plugin-relay:
     dependencies:
@@ -889,7 +895,7 @@ importers:
         version: 2.3.1(eslint@10.3.0(jiti@2.6.1))
       eslint-vitest-rule-tester:
         specifier: 'catalog:'
-        version: 3.1.0(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 3.1.0(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       ts-config:
         specifier: workspace:@animedes/ts-config@*
         version: link:../ts-config
@@ -898,7 +904,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/extra-outlet:
     dependencies:
@@ -1006,7 +1012,7 @@ importers:
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: 'catalog:'
-        version: 5.4.0(tinybench@2.9.0)(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 5.4.0(tinybench@2.9.0)(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
@@ -1030,7 +1036,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/markdown:
     dependencies:
@@ -1090,7 +1096,7 @@ importers:
         version: 0.4.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@codspeed/vitest-plugin':
         specifier: 'catalog:'
-        version: 5.4.0(tinybench@2.9.0)(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 5.4.0(tinybench@2.9.0)(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       eslint:
         specifier: 'catalog:'
         version: 10.3.0(jiti@2.6.1)
@@ -1117,7 +1123,7 @@ importers:
         version: link:../utilities
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/utilities:
     devDependencies:
@@ -2783,6 +2789,9 @@ packages:
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
     cpu: [arm]
@@ -3224,8 +3233,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -3236,8 +3257,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
     resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -3248,8 +3281,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3260,8 +3305,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -3272,8 +3329,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3284,8 +3353,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -3295,8 +3376,19 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
     resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -3307,8 +3399,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-rc.18':
     resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -4375,6 +4476,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-kit@2.2.0:
+    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
+    engines: {node: '>=20.19.0'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -4472,6 +4577,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -5814,6 +5923,10 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  magic-string-ast@1.0.3:
+    resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
+    engines: {node: '>=20.19.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -6609,8 +6722,22 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown-string@0.3.0:
+    resolution: {integrity: sha512-qGhBPNSv/27uzFBQdO+Cs4YAXC/1PKznD7Jz5Fl7NIAIlteuTPBTBWBhCpJ2AFTqLsoKvvUr7wSjqSUip0Fkpg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      rolldown: '*'
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+
   rolldown@1.0.0-rc.18:
     resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7165,6 +7292,10 @@ packages:
       svelte:
         optional: true
 
+  unplugin-macros@0.20.0:
+    resolution: {integrity: sha512-iEdXyXRkdm8Qn8WhRs+SRUOwL7Wrxic55dGG4i3fYly2WZlzA2mDUPKDGOKOjAj5oce+ZYtyrsj+0WCvqPrr7Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
     engines: {node: '>=20.19.0'}
@@ -7172,6 +7303,10 @@ packages:
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
+
+  unplugin@3.0.0:
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
@@ -7227,6 +7362,11 @@ packages:
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite-node@6.0.0:
+    resolution: {integrity: sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   vite-plugin-babel@1.6.0:
@@ -7293,6 +7433,49 @@ packages:
 
   vite@8.0.11:
     resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.13:
+    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -7870,12 +8053,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@codspeed/vitest-plugin@5.4.0(tinybench@2.9.0)(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@codspeed/vitest-plugin@5.4.0(tinybench@2.9.0)(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@codspeed/core': 5.4.0
       tinybench: 2.9.0
-      vite: 8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - debug
 
@@ -9147,6 +9330,8 @@ snapshots:
 
   '@oxc-project/types@0.128.0': {}
 
+  '@oxc-project/types@0.130.0': {}
+
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
 
@@ -9447,37 +9632,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.1':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
@@ -9487,13 +9708,28 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.18': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
@@ -9956,14 +10192,14 @@ snapshots:
 
   '@stryker-mutator/util@9.6.1': {}
 
-  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.12.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.12.3))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@stryker-mutator/api': 9.6.1
       '@stryker-mutator/core': 9.6.1(@types/node@24.12.3)
       '@stryker-mutator/util': 9.6.1
       semver: 7.7.4
       tslib: 2.8.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
@@ -10466,14 +10702,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.3(@types/node@24.12.3)(typescript@6.0.3)
-      vite: 8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.5(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -10483,6 +10719,15 @@ snapshots:
     optionalDependencies:
       msw: 2.14.3(@types/node@25.5.2)(typescript@6.0.3)
       vite: 8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.5(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.3(@types/node@25.5.2)(typescript@6.0.3)
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10697,6 +10942,11 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-kit@2.2.0:
+    dependencies:
+      '@babel/parser': 7.29.2
+      pathe: 2.0.3
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -10813,6 +11063,8 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cac@7.0.0: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -11406,11 +11658,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint-vitest-rule-tester@3.1.0(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  eslint-vitest-rule-tester@3.1.0(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@typescript-eslint/utils': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
       eslint: 10.3.0(jiti@2.6.1)
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -12273,6 +12525,10 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  magic-string-ast@1.0.3:
+    dependencies:
+      magic-string: 0.30.21
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -13066,6 +13322,12 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown-string@0.3.0(rolldown@1.0.1):
+    dependencies:
+      magic-string: 0.30.21
+    optionalDependencies:
+      rolldown: 1.0.1
+
   rolldown@1.0.0-rc.18:
     dependencies:
       '@oxc-project/types': 0.128.0
@@ -13086,6 +13348,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
+
+  rolldown@1.0.1:
+    dependencies:
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
 
   rollup@4.60.1:
     dependencies:
@@ -13681,6 +13964,30 @@ snapshots:
     optionalDependencies:
       '@svgr/core': 8.1.0(typescript@6.0.3)
 
+  unplugin-macros@0.20.0(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(rolldown@1.0.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      '@babel/types': 7.29.0
+      ast-kit: 2.2.0
+      magic-string-ast: 1.0.3
+      rolldown-string: 0.3.0(rolldown@1.0.1)
+      unplugin: 3.0.0
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 6.0.0(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   unplugin-utils@0.3.1:
     dependencies:
       pathe: 2.0.3
@@ -13690,6 +13997,12 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@3.0.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
@@ -13761,6 +14074,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@6.0.0(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 7.0.0
+      es-module-lexer: 2.0.0
+      obug: 2.1.1
+      pathe: 2.0.3
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   vite-plugin-babel@1.6.0(@babel/core@7.29.0)(vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -13805,21 +14139,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rolldown: 1.0.0-rc.18
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 24.12.3
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      tsx: 4.21.0
-      yaml: 2.8.3
-
   vite@8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -13835,10 +14154,40 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.3
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.5.2
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(msw@2.14.3(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -13855,7 +14204,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.13(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -13884,6 +14233,34 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.11(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.5.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.14.3(@types/node@25.5.2)(typescript@6.0.3))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -110,6 +110,7 @@ catalog:
   typescript: 6.0.3
   typescript-eslint: 8.59.2
   unplugin-icons: 23.0.1
+  unplugin-macros: 0.20.0
   vite: 8.0.11
   vite-plugin-babel: 1.6.0
   vite-plugin-inspect: 11.3.3


### PR DESCRIPTION
# Changes

- Refactored code to use macros for improved maintainability and reduced code duplication

## Summary by Sourcery

Adopt macro-based styling for web components and simplify the unstyled styling core to use plain objects instead of a class, while wiring up build tooling for macros and aligning internal imports with explicit file extensions.

New Features:
- Introduce macro-based style modules for Badge and Breadcrumb components using precompiled styles and a shared create helper.
- Enable macros in the web app build pipeline via the unplugin-macros Vite plugin.

Enhancements:
- Refactor OutStyles from a class to a simple interface with object literals, simplifying style creation and merging.
- Adjust unstyled and design package imports to use explicit .ts/.tsx extensions for better tooling compatibility.
- Update Box and related unstyled utilities to work with the new OutStyles shape and separate type-only imports.
- Add dedicated style modules for Badge and Breadcrumb to centralize and reuse their styling definitions.

Build:
- Configure Vite in the web app to register the unplugin-macros plugin and add it to workspace dependencies and catalog.

Tests:
- Update unstyled CVA tests to import modules via explicit .ts extensions to match the new module resolution setup.