### PR TITLE
🔧 Replace fragment shorthand with Fragment component

### DIFF
--- a/apps/web/app/routes/UserListSelected/route.tsx
+++ b/apps/web/app/routes/UserListSelected/route.tsx
@@ -13,7 +13,7 @@ import { precompileStyles } from "@anitrove/unstyled"
 import type { AnitomyResult } from "anitomy"
 
 import type { ReactNode } from "react"
-import { Suspense } from "react"
+import { Fragment, Suspense } from "react"
 
 import * as Ariakit from "@ariakit/react"
 import { Card } from "~/components/Card"
@@ -281,7 +281,7 @@ function AwaitList(props: Route.ComponentProps) {
 					const entry = allEntries.get(id)
 
 					return (
-						<>
+						<Fragment key={id}>
 							<MediaListItem key={id} data-key={id} media={media} entry={entry}>
 								<Skeleton>
 									{entry ? (
@@ -348,7 +348,7 @@ function AwaitList(props: Route.ComponentProps) {
 									)
 								})
 								.toArray()}
-						</>
+						</Fragment>
 					)
 				})
 				.toArray()}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use an explicit, keyed Fragment component instead of fragment shorthand around MediaListItem elements in the UserListSelected route.