### PR TITLE
remove unused imports

### DIFF
--- a/apps/web/app/routes/Home/UserLink.tsx
+++ b/apps/web/app/routes/Home/UserLink.tsx
@@ -30,7 +30,7 @@ import { type clientLoader as rootLoader } from "~/root"
 
 import { A } from "@anitrove/a"
 import type { UserLinkCardQuery } from "~/gql/UserLinkCardQuery.graphql"
-import { numberToString } from "~/lib/numberToString"
+
 import { m } from "~/lib/paraglide"
 import type { clientAction as userFollowAction } from "../UserFollow/route"
 import { precompileStyles } from "@anitrove/unstyled"

--- a/apps/web/app/routes/User/route.tsx
+++ b/apps/web/app/routes/User/route.tsx
@@ -65,7 +65,6 @@ import { data as json } from "react-router"
 import { Breadcrumb, BreadcrumbItem } from "~/components/Breadcrumb"
 import { LayoutBody, LayoutPane } from "~/components/Layout"
 import { Tabs, TabsPanel } from "~/components/Tabs"
-import { numberToString } from "~/lib/numberToString"
 
 export default function Index({ loaderData }: Route.ComponentProps): ReactNode {
 	const data = usePreloadedQuery(loaderData.routeNavUserQuery)

--- a/packages/eslint-plugin-jsx/src/no-unused-return-values.spec.ts
+++ b/packages/eslint-plugin-jsx/src/no-unused-return-values.spec.ts
@@ -1,7 +1,7 @@
 import * as typescriptParser from "@typescript-eslint/parser"
 import { createRuleTester } from "eslint-vitest-rule-tester"
 import path from "node:path"
-import { describe, expect, test } from "vitest"
+import { expect, test } from "vitest"
 import { rule } from "./no-unused-return-values"
 
 const { valid, invalid } = createRuleTester({

--- a/packages/eslint-plugin-jsx/src/rule-must-include-data-key.spec.ts
+++ b/packages/eslint-plugin-jsx/src/rule-must-include-data-key.spec.ts
@@ -1,6 +1,6 @@
 import * as typescriptParser from "@typescript-eslint/parser"
 import { createRuleTester } from "eslint-vitest-rule-tester"
-import { describe, expect, test } from "vitest"
+import { expect, test } from "vitest"
 import { rule } from "./rule-must-include-data-key"
 
 const { valid, invalid } = createRuleTester({

--- a/packages/eslint-plugin-jsx/src/rule-name-context.spec.ts
+++ b/packages/eslint-plugin-jsx/src/rule-name-context.spec.ts
@@ -1,6 +1,6 @@
 import * as typescriptParser from "@typescript-eslint/parser"
 import { createRuleTester } from "eslint-vitest-rule-tester"
-import { describe, expect, test } from "vitest"
+import { expect, test } from "vitest"
 import { rule } from "./rule-name-context"
 
 const { valid, invalid } = createRuleTester({

--- a/packages/eslint-plugin-relay/src/rule-must-colocate-fragment-spreads.spec.ts
+++ b/packages/eslint-plugin-relay/src/rule-must-colocate-fragment-spreads.spec.ts
@@ -1,6 +1,6 @@
 import * as typescriptParser from "@typescript-eslint/parser"
 import { createRuleTester } from "eslint-vitest-rule-tester"
-import { describe, expect, test } from "vitest"
+import { expect, test } from "vitest"
 import { rule } from "./rule-must-colocate-fragment-spreads"
 
 const { valid, invalid } = createRuleTester({

--- a/packages/unstyled/src/unstyled-cva.bench.ts
+++ b/packages/unstyled/src/unstyled-cva.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe } from "vitest"
+import { bench } from "vitest"
 import { cva } from "./unstyled-cva.ts"
 
 bench("empty", () => {


### PR DESCRIPTION
## Summary by Sourcery

Remove unused test and route imports to clean up lint warnings and dead code.

Enhancements:
- Remove unused Vitest imports from multiple ESLint rule spec files.
- Remove an unused helper import from the User route component.

Chores:
- Tidy up unused imports across packages to keep the codebase consistent with linting rules.