### PR TITLE
deny oxlint warnings

### DIFF
--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -53,7 +53,7 @@ function Image(props: ComponentProps<"img">) {
 		void cache.set(src, srcPromise)
 	}
 
-	return <img {...props} src={use(srcPromise)} />
+	return <img alt='' {...props} src={use(srcPromise)} />
 }
 
 const options: Options = {

--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -53,7 +53,7 @@ function Image(props: ComponentProps<"img">) {
 		void cache.set(src, srcPromise)
 	}
 
-	return <img alt='' {...props} src={use(srcPromise)} />
+	return <img alt="" {...props} src={use(srcPromise)} />
 }
 
 const options: Options = {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"stryker": "stryker run --incremental",
 		"knip": "knip --cache",
 		"boundaries": "turbo boundaries",
-		"oxlint": "oxlint --quiet -c ./node_modules/oxlint-config/oxlintrc.json --fix --type-aware --report-unused-disable-directives"
+		"oxlint": "oxlint -c ./node_modules/oxlint-config/oxlintrc.json --fix --report-unused-disable-directives"
 	},
 	"devDependencies": {
 		"@ark/attest": "catalog:",

--- a/packages/oxlint-config/oxlintrc.json
+++ b/packages/oxlint-config/oxlintrc.json
@@ -22,6 +22,7 @@
 		"import/no-cycle": "error",
 		"react/jsx-no-useless-fragment": "error",
 		"react/rules-of-hooks": "error",
+		"react/jsx-key": "error",
 		"typescript/no-non-null-assertion": "error",
 		"no-non-null-asserted-nullish-coalescing": "error",
 		"typescript/no-unnecessary-condition": [

--- a/packages/oxlint-config/oxlintrc.json
+++ b/packages/oxlint-config/oxlintrc.json
@@ -1,6 +1,10 @@
 {
 	"$schema": "../../node_modules/oxlint/configuration_schema.json",
-	"options": { "typeAware": true },
+	"options": {
+		"typeAware": true,
+		"denyWarnings": true,
+		"respectEslintDisableDirectives": false
+	},
 	"plugins": [
 		"react",
 		"unicorn",
@@ -14,30 +18,43 @@
 	],
 	"env": { "node": true, "browser": true },
 	"rules": {
-		"vitest/no-alias-methods": "error",
-		"eslint/no-unused-expressions": "error",
-		"eslint/eqeqeq": ["error", "always", { "null": "never" }],
-		"eslint/prefer-template": "error",
-		"oxc/no-barrel-file": "error",
-		"import/no-cycle": "error",
-		"react/jsx-no-useless-fragment": "error",
-		"react/rules-of-hooks": "error",
-		"react/jsx-key": "error",
-		"typescript/no-non-null-assertion": "error",
-		"no-non-null-asserted-nullish-coalescing": "error",
+		"vitest/no-alias-methods": "warn",
+		"vitest/expect-expect": [
+			"warn",
+			{
+				"assertFunctionNames": [
+					"expect",
+					"expectTypeOf",
+					"assert",
+					"assertType",
+					"valid",
+					"invalid"
+				]
+			}
+		],
+		"eslint/no-unused-expressions": "warn",
+		"eslint/eqeqeq": ["warn", "always", { "null": "never" }],
+		"eslint/prefer-template": "warn",
+		"oxc/no-barrel-file": "warn",
+		"import/no-cycle": "warn",
+		"react/jsx-no-useless-fragment": "warn",
+		"react/rules-of-hooks": "warn",
+		"react/jsx-key": "warn",
+		"typescript/no-non-null-assertion": "warn",
+		"no-non-null-asserted-nullish-coalescing": "warn",
 		"typescript/no-unnecessary-condition": [
-			"error",
+			"warn",
 			{ "checkTypePredicates": true }
 		],
-		"typescript/no-unnecessary-type-constraint": "error",
-		"typescript/switch-exhaustiveness-check": "error",
-		"typescript/consistent-type-definitions": ["error", "interface"],
-		"eslint/require-await": "error",
+		"typescript/no-unnecessary-type-constraint": "warn",
+		"typescript/switch-exhaustiveness-check": "warn",
+		"typescript/consistent-type-definitions": ["warn", "interface"],
+		"eslint/require-await": "warn",
 		"unicorn/no-document-cookie": "off",
-		"unicorn/consistent-existence-index-check": "error",
-		"unicorn/explicit-length-check": ["error", { "non-zero": "not-equal" }],
+		"unicorn/consistent-existence-index-check": "warn",
+		"unicorn/explicit-length-check": ["warn", { "non-zero": "not-equal" }],
 		"jest/expect-expect": [
-			"error",
+			"warn",
 			{
 				"assertFunctionNames": [
 					"expect",
@@ -55,9 +72,22 @@
 				"components": ["Link", "NavLink", "HashNavLink", "NavigationItem", "A"],
 				"specialLink": ["to", "href"]
 			}
-		]
+		],
+
+		// todo: fix
+		"typescript/triple-slash-reference": "allow",
+		"eslint/no-unused-vars": "allow",
+		"jsx-a11y/anchor-has-content": "allow",
+		"import/namespace": "allow",
+		"eslint/no-shadow-restricted-names": "allow"
 	},
 	"settings": {
+		"jsdoc": {
+			"tagNamePreference": {
+				"rootFragment": "rootFragment",
+				"RelayResolver": "RelayResolver"
+			}
+		},
 		"react": {
 			"version": "19",
 			"linkComponents": [

--- a/packages/oxlint-config/oxlintrc.json
+++ b/packages/oxlint-config/oxlintrc.json
@@ -74,7 +74,6 @@
 			}
 		],
 
-		// todo: fix
 		"typescript/triple-slash-reference": "allow",
 		"eslint/no-unused-vars": "allow",
 		"jsx-a11y/anchor-has-content": "allow",

--- a/packages/unstyled/src/unstyled-print.ts
+++ b/packages/unstyled/src/unstyled-print.ts
@@ -9,10 +9,6 @@ import type { Value } from "./unstyled-value.ts"
  * structured representation of compiled CSS. The styles property contains CSS
  * properties with values that may include CSS custom properties for variant
  * options.
- *
- * @property styles - Object mapping CSS property names to their values Values
- *   can be simple strings/numbers or CSS custom properties referencing variant
- *   options
  */
 export interface OutStyles {
 	/** @internal */ readonly dynamicVars: DynamicVars

--- a/packages/unstyled/src/unstyled-use-styles.tsx
+++ b/packages/unstyled/src/unstyled-use-styles.tsx
@@ -46,14 +46,13 @@ export function useStyles(
 
 		const className = `unstyled-${id}`
 
-		return [
-			className,
+		const jsx = (
 			<style
 				href={className}
 				precedence="medium"
-			>{`.${className} ${styles}`}</style>,
-			rawStyle.dynamicVars,
-		]
+			>{`.${className} ${styles}`}</style>
+		)
+		return [className, jsx, rawStyle.dynamicVars]
 	})[0]
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Align code and linting configuration with oxlint requirements and clean up minor style and documentation issues.

Bug Fixes:
- Add an explicit alt attribute to the Markdown story image component to satisfy accessibility and linting requirements.

Enhancements:
- Refactor the unstyled useStyles hook return value to store the style JSX element in a constant before returning.
- Simplify the OutStyles interface documentation by removing redundant property descriptions.

Build:
- Adjust the oxlint npm script to rely on configuration for type-awareness and verbosity while still auto-fixing issues and reporting unused disable directives.