### PR TITLE
🔧 Add oxc config path to VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,4 @@
-{ "relay.rootDirectory": "./apps/web" }
+{
+	"relay.rootDirectory": "./apps/web",
+	"oxc.configPath": "./node_modules/oxlint-config/oxlintrc.json"
+}


### PR DESCRIPTION
## Summary by Sourcery

Update the VSCode workspace settings to include the oxc configuration path for editor tooling integration.