### PR TITLE
🔧 Disable npm cache in Node setup

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -79,6 +80,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -112,6 +114,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -152,6 +155,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -108,6 +109,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -136,6 +138,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -166,6 +169,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -192,6 +196,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Turn off the setup-node package-manager-cache across test, deploy, Chromatic, Codspeed, format, and update-screenshots workflows to avoid using npm/pnpm caches in CI.