### PR TITLE
🎨 refactor: extract Layout styles to macro module

### DIFF
--- a/apps/web/app/components/Layout.styles.tsx
+++ b/apps/web/app/components/Layout.styles.tsx
@@ -1,0 +1,53 @@
+import { create, is, Var } from "@anitrove/unstyled"
+import { createContext, use, type ComponentProps, type ReactNode } from "react"
+
+import * as design from "@anitrove/design"
+import {
+	cva,
+	defineCva,
+	mergeStyles,
+	precompileStyles,
+	provide,
+	type CvaProps,
+	type OutStyles,
+} from "@anitrove/unstyled"
+import { Box } from "@anitrove/unstyled/box"
+
+export const Navigation = new Var<"bar" | "drawer" | "none" | "rail">(
+	"--navigation"
+)
+
+export const Variant = new Var<"fixed" | "flexible">("--variant")
+
+export const styles = create({
+	layout: { isolation: "isolate" },
+	body: {
+		...design.utilities.marginEnd({
+			base: "1rem",
+			[design.media.sm]: "1.5rem",
+		}),
+		display: "flex",
+		gap: "1.5rem",
+		...design.utilities.marginStart({
+			base: "1rem",
+			[is(Navigation, "none", "bar")]: { [design.media.sm]: "1.5rem" },
+			[is(Navigation, "rail")]: "5rem",
+			[is(Navigation, "drawer")]: "22.5rem",
+		}),
+		...design.utilities.paddingBottom({ [is(Navigation, "bar")]: "5rem" }),
+	},
+	pane: {
+		display: "block",
+		position: "relative",
+		overflowY: "auto",
+		overflowX: "hidden",
+		borderRadius: design.tokens.borderRadius.md,
+
+		width: {
+			[is(Variant, "fixed")]: "22.5rem",
+			[is(Variant, "flexible")]: "100%",
+		},
+		flexShrink: { [is(Variant, "fixed")]: 0 },
+		flexGrow: { [is(Variant, "flexible")]: 1 },
+	},
+})

--- a/apps/web/app/components/Layout.tsx
+++ b/apps/web/app/components/Layout.tsx
@@ -1,82 +1,28 @@
-import { createContext, use, type ComponentProps, type ReactNode } from "react"
+import { type ComponentProps, type ReactNode } from "react"
 
-import * as design from "@anitrove/design"
-import {
-	cva,
-	defineCva,
-	mergeStyles,
-	type CvaProps,
-	type OutStyles,
-} from "@anitrove/unstyled"
+import { mergeStyles, provide, type OutStyles } from "@anitrove/unstyled"
 import { Box } from "@anitrove/unstyled/box"
-const layoutDefinition = defineCva({
-	base: { isolation: "isolate" },
-	variants: { navigation: { none: {}, bar: {}, rail: {}, drawer: {} } },
-	defaultVariants: { navigation: "none" },
-})
 
-const layout = cva(layoutDefinition)
+import {
+	Navigation,
+	styles,
+	Variant,
+} from "./Layout.styles" with { type: "macro" }
 
-const body = cva({
-	base: {
-		...design.utilities.marginEnd({
-			base: "1rem",
-			[design.media.sm]: "1.5rem",
-		}),
-		display: "flex",
-		gap: "1.5rem",
-	},
-	variants: {
-		navigation: {
-			none: {
-				...design.utilities.marginStart({
-					base: "1rem",
-					[design.media.sm]: "1.5rem",
-				}),
-			},
-			bar: {
-				...design.utilities.marginStart({
-					base: "1rem",
-					[design.media.sm]: "1.5rem",
-				}),
-				...design.utilities.paddingBottom("5rem"),
-			},
-			rail: { ...design.utilities.marginStart("5rem") },
-			drawer: { ...design.utilities.marginStart("22.5rem") },
-		},
-	},
-	defaultVariants: { navigation: "none" },
-})
-
-const LayoutContext = createContext({
-	layout: mergeStyles(layout.style, layout.variants({})),
-	body: mergeStyles(body.style, body.variants({})),
-})
-LayoutContext.displayName = "LayoutContext"
-
-const LayoutNavigationContext =
-	createContext<CvaProps<typeof layoutDefinition>["navigation"]>(undefined)
-LayoutNavigationContext.displayName = "LayoutNavigationContext"
-
-interface LayoutProps
-	extends
-		CvaProps<typeof layoutDefinition>,
-		Omit<ComponentProps<"div">, "className" | "style"> {
+interface LayoutProps extends Omit<
+	ComponentProps<"div">,
+	"className" | "style"
+> {
 	style?: OutStyles
+	navigation?: typeof Navigation.$T
 }
 
-export function Layout({ style, navigation, ...props }: LayoutProps) {
-	const styles = {
-		layout: mergeStyles(layout.style, layout.variants({ navigation })),
-		body: mergeStyles(body.style, body.variants({ navigation })),
-	}
-
+export function Layout({ style, navigation = "none", ...props }: LayoutProps) {
 	return (
-		<LayoutNavigationContext value={navigation}>
-			<LayoutContext value={styles}>
-				<Box {...props} style={mergeStyles(styles.layout, style)}></Box>
-			</LayoutContext>
-		</LayoutNavigationContext>
+		<Box
+			{...props}
+			style={mergeStyles(styles.layout, provide(Navigation, navigation), style)}
+		></Box>
 	)
 }
 
@@ -88,56 +34,29 @@ interface LayoutBodyProps extends Omit<
 }
 
 export function LayoutBody({ style, ...props }: LayoutBodyProps): ReactNode {
-	const styles = use(LayoutContext)
-
 	return (
 		<Box render={<main {...props} />} style={mergeStyles(styles.body, style)} />
 	)
 }
 
-const paneDefinition = defineCva({
-	base: {
-		display: "block",
-		position: "relative",
-		overflowY: "auto",
-		overflowX: "hidden",
-		borderRadius: design.tokens.borderRadius.md,
-	},
-	variants: {
-		variant: {
-			fixed: { width: "22.5rem", flexShrink: 0 },
-			flexible: { width: "100%", flexGrow: 1 },
-		},
-		navigation: { none: {}, bar: {}, rail: {}, drawer: {} },
-	},
-	defaultVariants: { variant: "flexible", navigation: "none" },
-})
-
-const pane = cva(paneDefinition)
-
 import * as Ariakit from "@ariakit/react"
-interface LayoutPaneProps
-	extends
-		CvaProps<typeof paneDefinition>,
-		Omit<Ariakit.RoleProps<"section">, "className" | "style"> {
+interface LayoutPaneProps extends Omit<
+	Ariakit.RoleProps<"section">,
+	"className" | "style"
+> {
 	style?: OutStyles
+	variant?: typeof Variant.$T
 }
 
 export function LayoutPane({
 	style,
-	variant,
+	variant = 'flexible',
 	...props
 }: LayoutPaneProps): ReactNode {
-	const navigation = use(LayoutNavigationContext)
-
 	return (
 		<Box
 			render={<Ariakit.Role.section {...props}></Ariakit.Role.section>}
-			style={mergeStyles(
-				pane.style,
-				pane.variants({ navigation, variant }),
-				style
-			)}
+			style={mergeStyles(styles.pane, provide(Variant, variant), style)}
 		></Box>
 	)
 }

--- a/apps/web/app/components/Layout.tsx
+++ b/apps/web/app/components/Layout.tsx
@@ -50,7 +50,7 @@ interface LayoutPaneProps extends Omit<
 
 export function LayoutPane({
 	style,
-	variant = 'flexible',
+	variant = "flexible",
 	...props
 }: LayoutPaneProps): ReactNode {
 	return (

--- a/apps/web/app/routes/Nav/route.styles.tsx
+++ b/apps/web/app/routes/Nav/route.styles.tsx
@@ -1,0 +1,7 @@
+import * as design from "@anitrove/design"
+import { create } from "@anitrove/unstyled"
+import { Navigation } from "~/components/Layout.styles"
+
+export const styles = create({
+	layout: { [Navigation.name]: { base: "bar", [design.media.sm]: "rail" } },
+})

--- a/apps/web/app/routes/Nav/route.tsx
+++ b/apps/web/app/routes/Nav/route.tsx
@@ -30,8 +30,11 @@ import { Layout } from "~/components/Layout"
 import type { routeNavQuery } from "~/gql/routeNavQuery.graphql"
 
 import { A } from "@anitrove/a"
+import * as design from "@anitrove/design"
+import { precompileStyles } from "@anitrove/unstyled"
 import * as Ariakit from "@ariakit/react"
 import { ErrorBoundary } from "@sentry/react"
+import { Navigation as NavigationVar } from "~/components/Layout.styles"
 import { fab } from "~/lib/button"
 import {
 	loadQuery,
@@ -61,7 +64,7 @@ export const clientLoader = (args: Route.ClientLoaderArgs) => {
 
 	return { trending: data }
 }
-import * as design from "@anitrove/design"
+
 export default function NavRoute({
 	loaderData,
 }: Route.ComponentProps): ReactNode {
@@ -70,7 +73,11 @@ export default function NavRoute({
 	const { pathname } = useLocation()
 
 	return (
-		<Layout navigation={{ base: "bar", [design.media.sm]: "rail" }}>
+		<Layout
+			style={precompileStyles({
+				[NavigationVar.name]: { base: "bar", [design.media.sm]: "rail" },
+			})}
+		>
 			<Navigation className="navigation-bar sm:navigation-rail sm:navigation-start">
 				<Ariakit.ToolbarItem
 					render={

--- a/apps/web/app/routes/Nav/route.tsx
+++ b/apps/web/app/routes/Nav/route.tsx
@@ -30,11 +30,8 @@ import { Layout } from "~/components/Layout"
 import type { routeNavQuery } from "~/gql/routeNavQuery.graphql"
 
 import { A } from "@anitrove/a"
-import * as design from "@anitrove/design"
-import { precompileStyles } from "@anitrove/unstyled"
 import * as Ariakit from "@ariakit/react"
 import { ErrorBoundary } from "@sentry/react"
-import { Navigation as NavigationVar } from "~/components/Layout.styles"
 import { fab } from "~/lib/button"
 import {
 	loadQuery,
@@ -44,6 +41,7 @@ import {
 import MaterialSymbolsMenuBook from "~icons/material-symbols/menu-book"
 import MaterialSymbolsMenuBookOutline from "~icons/material-symbols/menu-book-outline"
 import type { Route } from "./+types/route"
+import { styles } from "./route.styles" with { type: "macro" }
 
 const { graphql } = ReactRelay
 
@@ -73,11 +71,7 @@ export default function NavRoute({
 	const { pathname } = useLocation()
 
 	return (
-		<Layout
-			style={precompileStyles({
-				[NavigationVar.name]: { base: "bar", [design.media.sm]: "rail" },
-			})}
-		>
+		<Layout style={styles.layout}>
 			<Navigation className="navigation-bar sm:navigation-rail sm:navigation-start">
 				<Ariakit.ToolbarItem
 					render={

--- a/packages/unstyled/src/unstyled-vars.ts
+++ b/packages/unstyled/src/unstyled-vars.ts
@@ -1,11 +1,12 @@
-import { numberOrStringToString } from "utilities"
-import type { OutStyles } from "./unstyled-print.ts"
+import { numberOrStringToString } from "utilities";
+import type { OutStyles } from "./unstyled-print.ts";
 
 export type Vars<Vars extends Record<string, number | string>> = {
 	[K in keyof Vars]: Var<Vars[K]>
 }
 
-export class Var<_T extends number | string> {
+export class Var<T extends number | string> {
+	public $T!: T;
 	/** @internal */
 	public name: `--${string}`
 	constructor(name: `--${string}`) {

--- a/packages/unstyled/src/unstyled-vars.ts
+++ b/packages/unstyled/src/unstyled-vars.ts
@@ -1,12 +1,12 @@
-import { numberOrStringToString } from "utilities";
-import type { OutStyles } from "./unstyled-print.ts";
+import { numberOrStringToString } from "utilities"
+import type { OutStyles } from "./unstyled-print.ts"
 
 export type Vars<Vars extends Record<string, number | string>> = {
 	[K in keyof Vars]: Var<Vars[K]>
 }
 
 export class Var<T extends number | string> {
-	public $T!: T;
+	public $T!: T
 	/** @internal */
 	public name: `--${string}`
 	constructor(name: `--${string}`) {


### PR DESCRIPTION
## Summary by Sourcery

Extract layout and navigation styling into reusable macro-based style modules and simplify Layout components to consume the new style API.

Enhancements:
- Replace Layout context-based styling and CVA variants with macro-driven style variables and a centralized Layout.styles module.
- Introduce typed style variables for navigation mode and pane variant, and update unstyled Var to expose its underlying type for better type safety.
- Refactor Nav route to configure Layout navigation via a route-specific macro style instead of passing responsive navigation props.