### PR TITLE
relay before oxlint

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -36,7 +36,13 @@
 			"inputs": ["eslint.config.ts"],
 			"outputs": ["eslint-typegen.d.ts"]
 		},
-		"//#oxlint": {},
+		"//#oxlint": {
+			"dependsOn": [
+				"@animedes/web#relay",
+				"@animedes/web#router",
+				"@animedes/web#paraglide"
+			]
+		},
 		"lint": { "dependsOn": ["transit"] },
 		"//#lint": {},
 		"test-e2e": { "outputs": ["playwright-report/**", "test-results/**"] },


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Tweak turbo.json configuration related to the sequencing of relay and oxlint tasks.