### PR TITLE
ci: run pnpm install through Socket Firewall

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -41,7 +45,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build packages
         run: pnpm exec turbo --filter=@animedes/storybook^... build

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Benchmark
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -41,7 +45,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
     name: Deploy Sentry
     runs-on: ubuntu-latest
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -41,7 +45,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build
         run: pnpm exec turbo --filter=@animedes/web build
@@ -59,6 +63,10 @@ jobs:
     name: Deploy Cloudflare Pages
     runs-on: ubuntu-latest
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -73,7 +81,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build
         run: pnpm exec turbo --filter=@animedes/web build
@@ -88,6 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Coverage
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -102,7 +114,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Check
         run: pnpm exec turbo check
@@ -124,6 +136,10 @@ jobs:
 
     name: Bundlewatch
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -138,7 +154,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Bundlewatch
         run: pnpm -w bundlewatch

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,6 +28,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -43,7 +47,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Lint
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
     container: ${{ case(matrix.project == 'electron', null, 'mcr.microsoft.com/playwright:v1.60.0-jammy') }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -51,7 +55,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install playwright 📦
         run: pnpm --filter=web exec playwright install --with-deps
@@ -84,6 +88,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Typecheck
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -98,7 +106,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Typecheck
         run: pnpm -w check
@@ -108,6 +116,10 @@ jobs:
 
     name: Knip
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -122,7 +134,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Relay
         run: pnpm exec turbo relay router paraglide
@@ -135,6 +147,10 @@ jobs:
 
     name: Boundaries
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -148,7 +164,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Boundaries
         run: pnpm -w boundaries
@@ -156,6 +172,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           filter: blob:none
@@ -170,7 +190,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Test
         run: pnpm exec turbo test

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -29,6 +29,10 @@ jobs:
       contents: write # needs to push changes
 
     steps:
+      - name: Install Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f
+        with:
+          mode: firewall-free
       - name: Checkout selected branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -45,7 +49,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies 📦
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install playwright 📦
         run: pnpm --filter=web exec playwright install --with-deps


### PR DESCRIPTION
Adds the socketdev/action setup step to every job that installs dependencies
and prefixes each pnpm install with sfw so installs flow through the Socket
Firewall in firewall-free mode. Covers codspeed, update-screenshots, format,
test (all 5 jobs), chromatic, and deploy (all 4 jobs). zizmor has no install
step and is unchanged.

## Summary by Sourcery

Route dependency installation in CI workflows through Socket Firewall in firewall-free mode for improved supply-chain security.

CI:
- Add Socket Firewall setup step to CI jobs that install dependencies across test, deploy, chromatic, codspeed, format, and update-screenshots workflows.
- Prefix pnpm install commands with the Socket Firewall wrapper in all affected workflows to ensure installations go through the firewall.