### PR TITLE
ci: gate turbo steps with `turbo query affected`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
             project: electron
           - os: windows-latest
             project: electron
-    container: ${{ case(matrix.project == 'electron', null, 'mcr.microsoft.com/playwright:v1.60.0-jammy') }}
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Socket Firewall
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install playwright 📦
         run: pnpm --filter=web exec playwright install --with-deps
-        if: steps.affected-test-e2e.outcome == 'failure'  && matrix.project == 'electron'
+        if: steps.affected-test-e2e.outcome == 'failure'
         timeout-minutes: 5
 
       - name: Install xvfb 📦

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,16 +57,22 @@ jobs:
       - name: Install dependencies 📦
         run: sfw pnpm install --frozen-lockfile --prefer-offline
 
+      - name: Check affected — test-e2e
+        id: affected-test-e2e
+        continue-on-error: true
+        run: pnpm exec turbo query affected --tasks test-e2e --exit-code
+
       - name: Install playwright 📦
         run: pnpm --filter=web exec playwright install --with-deps
-        if: matrix.project == 'electron'
+        if: steps.affected-test-e2e.outcome == 'failure'  && matrix.project == 'electron'
         timeout-minutes: 5
 
       - name: Install xvfb 📦
-        if: matrix.os == 'ubuntu-latest' && matrix.project == 'electron'
+        if: steps.affected-test-e2e.outcome == 'failure'  && matrix.os == 'ubuntu-latest' && matrix.project == 'electron'
         run: sudo apt install -y xvfb
 
       - name: Test E2E
+        if: steps.affected-test-e2e.outcome == 'failure'
         run: ${{ matrix.os == 'ubuntu-latest' && matrix.project == 'electron' && 'xvfb-run --auto-servernum' || '' }} pnpm -w test-e2e -- --project=${{ matrix.project }}*
         env:
           ELECTRON_DISABLE_SANDBOX: 1


### PR DESCRIPTION
## Summary

Adds a `turbo query affected --exit-code` check before every `turbo <task>` step in CI so the step is skipped when nothing in scope is affected. Cuts wasted CI minutes on no-op branches (renovate digest bumps, docs-only PRs, etc.).

## Pattern

Each gated step is preceded by a `Check affected — <task>` step that runs `pnpm exec turbo query affected --tasks <task> [--packages <pkg>] --exit-code` with `continue-on-error: true`. The turbo step is then gated by `if: steps.<id>.outcome == 'failure'` — the inversion is intentional because `--exit-code` exits `1` when results are affected, `0` when nothing is affected.

## Files touched

- `format.yml` — Lint (`oxlint`/`lint`), Format. Preserves the existing `!cancelled()` guard.
- `chromatic.yml` — Build packages (`build` / `@animedes/storybook`).
- `codspeed.yml` — Run benchmarks (`bench`); `if:` lives on the `uses:` step.
- `deploy.yml` — Build x2 (`build` / `@animedes/web`), Check (`check`), Coverage (`stryker`).
- `test.yml` — Relay (`relay`/`router`/`paraglide`), Knip (`knip`), Test (`test`).

`zizmor.yml` and `update-screenshots.yml` have no direct `turbo` invocations and were left alone.

## Test plan

- [ ] Open a docs-only PR (no package code touched) — confirm Build / Test / Knip / Coverage steps are skipped.
- [ ] Open a PR touching `apps/web/**` — confirm `@animedes/web` Build still runs in `deploy.yml`.
- [ ] Open a PR touching `apps/storybook/**` — confirm Chromatic Build packages still runs.
- [ ] Confirm `master` push builds aren't accidentally skipped (`TURBO_SCM_BASE` falls back to `github.event.before`).

## Summary by Sourcery

CI:
- Add pre-check steps using `turbo query affected` before turbo build, test, lint, format, benchmark, and coverage tasks across workflows so those steps only run when relevant packages or tasks are affected.